### PR TITLE
Update amass.go

### DIFF
--- a/amass/amass.go
+++ b/amass/amass.go
@@ -114,7 +114,7 @@ func NewEnumeration() *Enumeration {
 	return &Enumeration{
 		Output:          make(chan *core.AmassOutput, 100),
 		Log:             log.New(ioutil.Discard, "", 0),
-		Ports:           []int{80, 443},
+		Ports:           []int{443},
 		Recursive:       true,
 		Alterations:     true,
 		MinForRecursive: 1,
@@ -150,7 +150,7 @@ func (e *Enumeration) generateAmassConfig() (*core.AmassConfig, error) {
 	}
 
 	if len(e.Ports) == 0 {
-		e.Ports = []int{80, 443}
+		e.Ports = []int{443}
 	}
 
 	if e.BruteForcing && len(e.Wordlist) == 0 {


### PR DESCRIPTION
Remove port 80 from the certificate grabbing function - we don't ever expect to see a certificate being served up on 80. Might be worth adding top 3 TLS ports to the default list in future - requires further investigation.