### PR TITLE
Update main.go

### DIFF
--- a/cmd/amass/main.go
+++ b/cmd/amass/main.go
@@ -61,7 +61,7 @@ func main() {
 	defaultBuf := new(bytes.Buffer)
 	flag.CommandLine.SetOutput(defaultBuf)
 
-	flag.Var(&ports, "p", "Ports separated by commas (default: 80,443)")
+	flag.Var(&ports, "p", "Ports separated by commas (default: 443)")
 	flag.Var(&domains, "d", "Domain names separated by commas (can be used multiple times)")
 	flag.Var(&resolvers, "r", "IP addresses of preferred DNS resolvers (can be used multiple times)")
 	flag.Var(&blacklist, "bl", "Blacklist of subdomain names that will not be investigated")


### PR DESCRIPTION
Remove port 80 from the certificate grabbing function - we don't ever expect to see a certificate being served up on 80. Might be worth adding top 3 TLS ports to the default list in future - requires further investigation.