### PR TITLE
Update crtsh.go

### DIFF
--- a/amass/sources/crtsh.go
+++ b/amass/sources/crtsh.go
@@ -59,7 +59,7 @@ func (c *Crtsh) Query(domain, sub string) []string {
 		} else if err != nil {
 			c.Service.Config().Log.Printf("%s: %v", url, err)
 		}
-		unique = append(unique, line.Name)
+		unique = utils.UniqueAppend(unique, removeAsteriskLabel(line.Name))
 	}
 	return unique
 }


### PR DESCRIPTION
Stop Amass from returning results with an asterisk (*) in the name as it isn't really useful to see - e.g., *.domain.com