### PR TITLE
cmd/amass: accept a gzipped file as wordlist

### DIFF
--- a/cmd/amass/main.go
+++ b/cmd/amass/main.go
@@ -238,43 +238,43 @@ func main() {
 
 func getLinesFromFile(path string) []string {
 	var lines []string
-	var r io.Reader
+	var reader io.Reader
 
 	// Open the file
 	file, err := os.Open(path)
 	if err != nil {
-		fmt.Printf("Error opening the file %s: %v\n", path, err)
+		r.Fprintf(os.Stderr, "Error opening the file %s: %v\n", path, err)
 		return lines
 	}
 	defer file.Close()
-	r = file
+	reader = file
 
-	// we need to determine if this is a gzipped file or a plain text file, so we
+	// We need to determine if this is a gzipped file or a plain text file, so we
 	// first read the first 512 bytes to pass them down to http.DetectContentType
 	// for mime detection. The file is rewinded before passing it along to the
 	// next reader
 	head := make([]byte, 512)
 	if _, err = file.Read(head); err != nil {
-		fmt.Printf("error reading the first 512 bytes from %s: %s\n", path, err)
+		r.Fprintf(os.Stderr, "Error reading the first 512 bytes from %s: %s\n", path, err)
 		return lines
 	}
 	if _, err = file.Seek(0, 0); err != nil {
-		fmt.Printf("error rewinding the file %s: %s\n", path, err)
+		r.Fprintf(os.Stderr, "Error rewinding the file %s: %s\n", path, err)
 		return lines
 	}
 
-	// read the file as gzip if it's actually compressed
+	// Read the file as gzip if it's actually compressed
 	if mt := http.DetectContentType(head); mt == "application/gzip" || mt == "application/x-gzip" {
 		gzReader, err := gzip.NewReader(file)
 		if err != nil {
-			fmt.Printf("Error gz-reading the file %s: %v\n", path, err)
+			r.Fprintf(os.Stderr, "Error gz-reading the file %s: %v\n", path, err)
 			return lines
 		}
 		defer gzReader.Close()
-		r = gzReader
+		reader = gzReader
 	}
 	// Get each line from the file
-	scanner := bufio.NewScanner(r)
+	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {
 		// Get the next line
 		text := scanner.Text()

--- a/cmd/amass/main.go
+++ b/cmd/amass/main.go
@@ -6,12 +6,14 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"compress/gzip"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
 	"log"
 	"math/rand"
+	"net/http"
 	"os"
 	"path"
 	"regexp"
@@ -236,6 +238,7 @@ func main() {
 
 func getLinesFromFile(path string) []string {
 	var lines []string
+	var r io.Reader
 
 	// Open the file
 	file, err := os.Open(path)
@@ -244,8 +247,34 @@ func getLinesFromFile(path string) []string {
 		return lines
 	}
 	defer file.Close()
+	r = file
+
+	// we need to determine if this is a gzipped file or a plain text file, so we
+	// first read the first 512 bytes to pass them down to http.DetectContentType
+	// for mime detection. The file is rewinded before passing it along to the
+	// next reader
+	head := make([]byte, 512)
+	if _, err = file.Read(head); err != nil {
+		fmt.Printf("error reading the first 512 bytes from %s: %s\n", path, err)
+		return lines
+	}
+	if _, err = file.Seek(0, 0); err != nil {
+		fmt.Printf("error rewinding the file %s: %s\n", path, err)
+		return lines
+	}
+
+	// read the file as gzip if it's actually compressed
+	if mt := http.DetectContentType(head); mt == "application/gzip" || mt == "application/x-gzip" {
+		gzReader, err := gzip.NewReader(file)
+		if err != nil {
+			fmt.Printf("Error gz-reading the file %s: %v\n", path, err)
+			return lines
+		}
+		defer gzReader.Close()
+		r = gzReader
+	}
 	// Get each line from the file
-	scanner := bufio.NewScanner(file)
+	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
 		// Get the next line
 		text := scanner.Text()


### PR DESCRIPTION
Allow the wordlists file to be gzipped by automatically un-gzipping it while reading it. For context, please see https://github.com/NixOS/nixpkgs/pull/50490#pullrequestreview-176085536