### PR TITLE
fix division by zero

### DIFF
--- a/amass/namesrv.go
+++ b/amass/namesrv.go
@@ -86,7 +86,9 @@ func (ns *NameService) processRequests() {
 			for _, s := range perSec {
 				total += s
 			}
-			ns.Enum().Log.Printf("Average DNS names processed: %d/sec", total/num)
+			if num > 0 {
+				ns.Enum().Log.Printf("Average DNS names processed: %d/sec", total/num)
+			}
 			perSec = []int{}
 		case req := <-ns.RequestChan():
 			go ns.performRequest(req)


### PR DESCRIPTION
fix #81 although I couldn't reproduce the error since the `t` timer should populate the array before the `logTick`