### PR TITLE
Add all binaries to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,8 @@ RUN apk --no-cache add git \
   && go get -u github.com/OWASP/Amass/...
   
 FROM alpine:latest
-COPY --from=build /go/bin/amass /bin/amass 
+COPY --from=build /go/bin/amass /bin/amass
+COPY --from=build /go/bin/amass.db /bin/amass.db
+COPY --from=build /go/bin/amass.netdomains /bin/amass.netdomains
+COPY --from=build /go/bin/amass.viz /bin/amass.viz
 ENTRYPOINT ["/bin/amass"]


### PR DESCRIPTION
This allows to use netdomains, db and viz with Docker.

E.g `sudo docker run --entrypoint "/bin/amass.netdomains" amass -org Facebook`
