### PR TITLE
More tests

### DIFF
--- a/amass/brute_test.go
+++ b/amass/brute_test.go
@@ -25,19 +25,19 @@ func TestBruteForceService(t *testing.T) {
 	defer e.bruteService.Stop()
 	e.nameService.Start()
 	defer e.nameService.Stop()
-	timer := time.NewTicker(time.Millisecond * 400)
-	defer timer.Stop()
 
 	expected := len(e.Config.Wordlist) * len(domains)
 	results := make(map[string]int)
 
+	timer := time.NewTimer(time.Second)
+	defer timer.Stop()
 loop:
 	for {
 		select {
 		case res := <-e.Output:
 			results[res.Name]++
 		case <-timer.C:
-			// break on a max 400 ms for this test
+			// break on a max 1s for this test
 			break loop
 		}
 	}

--- a/amass/brute_test.go
+++ b/amass/brute_test.go
@@ -3,35 +3,40 @@
 
 package amass
 
-/*
 import (
 	"testing"
+
+	"github.com/OWASP/Amass/amass/utils"
 )
 
 func TestBruteForceService(t *testing.T) {
 	domains := []string{"claritysec.com", "twitter.com", "google.com", "github.com"}
 
-	config := CustomConfig(&AmassConfig{
-		Wordlist:     []string{"foo", "bar"},
-		BruteForcing: true,
-	})
-	config.AddDomains(domains)
-	srv := NewBruteForceService(config)
-	srv.Start()
+	e := NewEnumeration()
+
+	e.Config.Wordlist = []string{"foo", "bar"}
+	e.Config.BruteForcing = true
+	e.Config.Passive = true
+	e.Config.AddDomains(domains)
+	e.MaxFlow = utils.NewTimedSemaphore(e.Config.Timing.ToMaxFlow(), e.Config.Timing.ToReleaseDelay())
+
+	e.bruteService.Start()
+	defer e.bruteService.Stop()
+	e.nameService.Start()
+	defer e.nameService.Stop()
 
 	// Setup the results we expect to see
 	results := make(map[string]int)
 	for _, domain := range domains {
-		for _, word := range config.Wordlist {
+		for _, word := range e.Config.Wordlist {
 			results[word+"."+domain] = 0
 		}
 	}
 
 	num := len(results)
 	for i := 0; i < num; i++ {
-		req := <-out
-
-		results[req.Name]++
+		res := <-e.Output
+		results[res.Name]++
 	}
 
 	if num != len(results) {
@@ -44,6 +49,4 @@ func TestBruteForceService(t *testing.T) {
 		}
 	}
 
-	srv.Stop()
 }
-*/

--- a/amass/config.go
+++ b/amass/config.go
@@ -112,6 +112,13 @@ func (c *Config) DomainRegex(domain string) *regexp.Regexp {
 	return nil
 }
 
+// AddDomains appends the domain names provided in the parameter to the list in the configuration.
+func (c *Config) AddDomains(domains []string) {
+	for _, d := range domains {
+		c.AddDomain(d)
+	}
+}
+
 // AddDomain appends the domain name provided in the parameter to the list in the configuration.
 func (c *Config) AddDomain(domain string) {
 	c.Lock()
@@ -151,7 +158,7 @@ func (c *Config) IsDomainInScope(name string) bool {
 	return discovered
 }
 
-// WhichDomain returns the domain in the config list that the DNS name in the parameter end with.
+// WhichDomain returns the domain in the config list that the DNS name in the parameter ends with.
 func (c *Config) WhichDomain(name string) string {
 	n := strings.TrimSpace(name)
 

--- a/amass/config_test.go
+++ b/amass/config_test.go
@@ -23,3 +23,34 @@ func TestExcludeDisabledDataSources(t *testing.T) {
 		t.Errorf("mismatched result, got %+v, want %+v", got, want)
 	}
 }
+
+func TestAddDomainsDuplicate(t *testing.T) {
+	domains := []string{"twitter.com", "google.com", "twitter.com"}
+
+	e := NewEnumeration()
+	e.Config.AddDomains(domains)
+
+	got := e.Config.Domains()
+	want := append(domains[0:2])
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("mismatched result, got %+v, want %+v", got, want)
+	}
+}
+
+func TestIsDomainInScope(t *testing.T) {
+	domain := "google.com"
+	inScope := "mail.google.com"
+	outOfScope := "mail.random.com"
+
+	e := NewEnumeration()
+	e.Config.AddDomain(domain)
+
+	if !e.Config.IsDomainInScope(inScope) {
+		t.Errorf("expected %s to be in the scope of %s", inScope, domain)
+	}
+
+	if e.Config.IsDomainInScope(outOfScope) {
+		t.Errorf("expected %s to be out of the scope of %s", outOfScope, domain)
+	}
+}

--- a/amass/crtsh_test.go
+++ b/amass/crtsh_test.go
@@ -1,0 +1,44 @@
+// Copyright 2017 Jeff Foley. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package amass
+
+/*
+import (
+	"sync"
+	"testing"
+)
+
+func TestCrtsh(t *testing.T) {
+
+	expected := 100
+	e := NewEnumeration()
+	var wg sync.WaitGroup
+
+	e.Config.Passive = true
+	e.Config.AddDomain("letsencrypt.owasp-amass.com")
+	e.dataSources = []Service{NewCrtsh(e)}
+
+	results := make(map[string]bool)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			req, ok := <-e.Output
+			if !ok {
+				break
+			}
+			results[req.Name] = true
+
+		}
+	}()
+
+	e.Start()
+	wg.Wait()
+
+	if expected != len(results) {
+		t.Errorf("Found %d names, expected %d instead", len(results), expected)
+	}
+
+}
+*/


### PR DESCRIPTION
Hi :) This pr contains the following:
* Fixed the old commented out brute_test.go
* Added back the AddDomains utility function in config.go
* A few more tests for config
* The test for issue #59 temporarily commented out since it returns 98 whereas `curl -s 'https://crt.sh/?q=%25.letsencrypt.owasp-amass.com&output=json' | grep -Po '\d+.letsencrypt\.owasp-amass\.com' | sort | uniq | wc -l` returns 100
