### PR TITLE
Added Wordlists to the Docker Build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,11 @@ WORKDIR /go/src/github.com/OWASP/Amass
 COPY . .
 RUN apk --no-cache add git \
   && go get -u github.com/OWASP/Amass/...
-  
+
 FROM alpine:latest
 COPY --from=build /go/bin/amass /bin/amass
 COPY --from=build /go/bin/amass.db /bin/amass.db
 COPY --from=build /go/bin/amass.netdomains /bin/amass.netdomains
 COPY --from=build /go/bin/amass.viz /bin/amass.viz
+COPY --from=build /go/src/github.com/OWASP/Amass/wordlists /wordlists
 ENTRYPOINT ["/bin/amass"]

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ sudo docker build -t amass https://github.com/OWASP/Amass.git
 sudo docker run amass --passive -d example.com
 ```
 
+The wordlists maintained in the Amass git repository are available in `/wordlists/` within the docker container. For example, to use `all.txt`:
+
+```bash
+sudo docker run amass -w /wordlists/all.txt -d example.com
+```
+
 ### From Source
 
 If you prefer to build your own binary from the latest release of the source code, make sure you have a correctly configured **Go >= 1.10** environment. More information about how to achieve this can be found [on the golang website.](https://golang.org/doc/install) Then, take the following steps:


### PR DESCRIPTION
Pretty straightforward. Just adding the wordlists to the docker build so they can be used from the docker container