### PR TITLE
Added goreleaser config for homebrew releases

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -98,3 +98,17 @@ changelog:
     exclude:
     - '^doc:'
     - '^test:'
+
+brew:
+  # Reporitory to push the tap to.
+  github:
+    owner: OWASP
+    name: homebrew-amass
+
+  # Your app's homepage.
+  # Default is empty.
+  homepage: 'https://www.owasp.org/index.php/OWASP_Amass_Project'
+
+  # Your app's description.
+  # Default is empty.
+  description: 'In-depth DNS Enumeration and Network Mapping'


### PR DESCRIPTION
Adds `goreleaser` config for publishing the amass binaries to a custom homebrew tap.

When all goes works and goes well this would mean that amass could be installed on macos by running:

```sh
brew tap OWASP/amass
brew install amass
```

Note: This would require the creation of a repository under `OWASP/homebrew-amass` where the release description for the homebrew tap would then be pushed into for every release.