### PR TITLE
Static wildcard test

### DIFF
--- a/amass/amass_test.go
+++ b/amass/amass_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	datasources = flag.Bool("datasources", false, "Run data source integration tests")
+	network = flag.Bool("network", false, "Run tests that require connectivity (take more time)")
 )
 
 // TestMain will parse the test flags and setup for integration tests.

--- a/amass/dnssrv.go
+++ b/amass/dnssrv.go
@@ -448,7 +448,7 @@ func (ds *DNSService) performWildcardRequest(req *core.Request) int {
 		} else if w.WildcardType == WildcardTypeStatic {
 			if len(req.Records) == 0 {
 				return WildcardTypeStatic
-			} else if ds.compareAnswers(req.Records, w.Answers) {
+			} else if compareAnswers(req.Records, w.Answers) {
 				return WildcardTypeStatic
 			}
 		}
@@ -479,7 +479,7 @@ func (ds *DNSService) getWildcard(sub string) *wildcard {
 		// Check if we have a static DNS wildcard
 		match := true
 		for i := 0; i < numOfWildcardTests-1; i++ {
-			if !ds.compareAnswers(set[i], set[i+1]) {
+			if !compareAnswers(set[i], set[i+1]) {
 				match = false
 				break
 			}
@@ -494,20 +494,6 @@ func (ds *DNSService) getWildcard(sub string) *wildcard {
 		}
 	}
 	return entry
-}
-
-func (ds *DNSService) compareAnswers(ans1, ans2 []core.DNSAnswer) bool {
-	var match bool
-loop:
-	for _, a1 := range ans1 {
-		for _, a2 := range ans2 {
-			if strings.EqualFold(a1.Data, a2.Data) {
-				match = true
-				break loop
-			}
-		}
-	}
-	return match
 }
 
 func (ds *DNSService) wildcardTestResults(sub string) []core.DNSAnswer {
@@ -535,6 +521,20 @@ func (ds *DNSService) wildcardTestResults(sub string) []core.DNSAnswer {
 		return nil
 	}
 	return answers
+}
+
+func compareAnswers(ans1, ans2 []core.DNSAnswer) bool {
+	var match bool
+loop:
+	for _, a1 := range ans1 {
+		for _, a2 := range ans2 {
+			if strings.EqualFold(a1.Data, a2.Data) {
+				match = true
+				break loop
+			}
+		}
+	}
+	return match
 }
 
 // UnlikelyName takes a subdomain name and returns an unlikely DNS name within that subdomain

--- a/amass/dnssrv.go
+++ b/amass/dnssrv.go
@@ -524,17 +524,14 @@ func (ds *DNSService) wildcardTestResults(sub string) []core.DNSAnswer {
 }
 
 func compareAnswers(ans1, ans2 []core.DNSAnswer) bool {
-	var match bool
-loop:
 	for _, a1 := range ans1 {
 		for _, a2 := range ans2 {
 			if strings.EqualFold(a1.Data, a2.Data) {
-				match = true
-				break loop
+				return true
 			}
 		}
 	}
-	return match
+	return false
 }
 
 // UnlikelyName takes a subdomain name and returns an unlikely DNS name within that subdomain


### PR DESCRIPTION
I just changed the flag to network for now.
* The test exits early on success or times out at 30 seconds.
* compareAnswers doesn't depend on dns service, it's more of a utility function so I separated it and refactored it (potentially easier than using labels).