### PR TITLE
Fixed Virustotal URL, fixes #151

### DIFF
--- a/amass/sources/virustotal.go
+++ b/amass/sources/virustotal.go
@@ -67,7 +67,7 @@ func (v *VirusTotal) executeQuery(domain string) {
 }
 
 func (v *VirusTotal) getURL(domain string) string {
-	format := "https://www.virustotal.com/en/domain/%s/information/"
+	format := "https://www.virustotal.com/ui/domains/%s/subdomains"
 
 	return fmt.Sprintf(format, domain)
 }


### PR DESCRIPTION
Apparently VT changed their URL, this fix changed the URL to the correct version. 
This change should fix issue #151