### PR TITLE
Add demo mode

### DIFF
--- a/amass/amass.go
+++ b/amass/amass.go
@@ -573,8 +573,8 @@ func PrintEnumerationSummary(total int, tags map[string]int, asns map[int]*ASNSu
 		datastr := data.Name
 
 		if demo && asn > 0 {
-			asnstr = censorString(asnstr, true)
-			datastr = censorString(datastr, true)
+			asnstr = censorString(asnstr, 0, len(asnstr))
+			datastr = censorString(datastr, 0, len(datastr))
 		}
 
 		fmt.Fprintf(color.Error, "%s%s %s %s\n",
@@ -585,7 +585,7 @@ func PrintEnumerationSummary(total int, tags map[string]int, asns map[int]*ASNSu
 			cidrstr := cidr
 
 			if demo {
-				cidrstr = censorString(cidrstr, true)
+				cidrstr = censorNetBlock(cidrstr)
 			}
 
 			countstr = fmt.Sprintf("\t%-4s", countstr)
@@ -620,17 +620,19 @@ func PrintBanner() {
 	y.Fprintf(color.Error, "%s\n\n\n", desc)
 }
 
-func censorString(input string, full bool) string {
-	var start, end int
+func censorDomain(input string) string {
+	return censorString(input, strings.Index(input, "."), len(input))
+}
 
-	if full {
-		start = 0
-	} else {
-		start = strings.Index(input, ".")
-	}
+func censorIP(input string) string {
+	return censorString(input, 0, strings.LastIndex(input, "."))
+}
 
-	end = len(input)
+func censorNetBlock(input string) string {
+	return censorString(input, 0, strings.Index(input, "/"))
+}
 
+func censorString(input string, start, end int) string {
 	runes := []rune(input)
 	for i := start; i < end; i++ {
 		if runes[i] == '.' ||
@@ -656,7 +658,7 @@ func OutputLineParts(out *core.Output, src, addrs, demo bool) (source, name, ips
 				ips += ","
 			}
 			if demo {
-				ips += censorString(a.Address.String(), false)
+				ips += censorIP(a.Address.String())
 			} else {
 				ips += a.Address.String()
 			}
@@ -667,7 +669,7 @@ func OutputLineParts(out *core.Output, src, addrs, demo bool) (source, name, ips
 	}
 	name = out.Name
 	if demo {
-		name = censorString(name, false)
+		name = censorDomain(name)
 	}
 	return
 }


### PR DESCRIPTION
Demo mode adds the ability to censor output to make it suitable for demonstrations of the tool without unnecessary exposure.

NOTE: This does not include the changes required in `cmd/main/amass.go` as that code is being reworked in a separate branch.

Example Output:
```
[HackerTarget]    l4d2.xxxxx.xxx xx.xxx.x.35
[HackerTarget]    l4d.xxxxx.xxx xx.xxx.x.34
[HackerTarget]    www-02-pub.xxxxx.xxx xx.xxx.x.64
[HackerTarget]    csgo.xxxxx.xxx xx.xxx.x.33
[SiteDossier]     library.xxxxx.xxx xx.xxx.x.113
[HackerTarget]    vdi.xxxx.xxxxx.xxx xx.xxx.x.55
^C
OWASP Amass v2.9.13                               https://github.com/OWASP/Amass
--------------------------------------------------------------------------------
115 names discovered - cert: 31, api: 76, scrape: 5, dns: 3
--------------------------------------------------------------------------------
ASN: xxxxx - xxxxxx - xxxxxx xxxx xx
        xxx.xxx.xx.x/19         1    Subdomain Name(s)
ASN: 0 - Private Networks
        xx.x.x.x/8              6    Subdomain Name(s)
        xxx.xxx.x.x/16          1    Subdomain Name(s)
```