### PR TITLE
Fix io.Pipe Deadlock when using amass intel -whois

### DIFF
--- a/cmd/amass/intel.go
+++ b/cmd/amass/intel.go
@@ -177,27 +177,30 @@ func runIntelCommand(clArgs []string) {
 	}
 
 	if args.Options.ReverseWhois {
-		var all []string
-
-		for _, domain := range args.Domains {
-			domains, err := intel.ReverseWhois(domain)
-			if err != nil {
-				continue
-			}
-			for _, d := range domains {
-				if name := strings.TrimSpace(d); name != "" {
-					all = utils.UniqueAppend(all, name)
-				}
-			}
-		}
-
-		for _, d := range all {
-			g.Println(d)
-		}
-		return
+		go performReverseWhois(intel, &args)
 	}
 
 	processIntelOutput(intel, &args, rLog)
+}
+
+func performReverseWhois(intel *amass.IntelCollection, args *intelArgs) {
+	var all []string
+
+	for _, domain := range args.Domains {
+		domains, err := intel.ReverseWhois(domain)
+		if err != nil {
+			continue
+		}
+		for _, d := range domains {
+			if name := strings.TrimSpace(d); name != "" {
+				all = utils.UniqueAppend(all, name)
+			}
+		}
+	}
+
+	for _, d := range all {
+		g.Println(d)
+	}
 }
 
 func processIntelOutput(intel *amass.IntelCollection, args *intelArgs, pipe *io.PipeReader) {


### PR DESCRIPTION
intel.ReverseWhois was trying to write to a pipe that could never be consumed because it was all in the same goroutine. This PR moves the whois logic to a separate goroutine so data can flow through the Pipe.