### PR TITLE
Amass/amass: add go.mod

### DIFF
--- a/amass/go.mod
+++ b/amass/go.mod
@@ -1,0 +1,3 @@
+module github.com/OWASP/Amass/amass
+
+go 1.12


### PR DESCRIPTION
Adds go module file so that amass can be imported using Go modules.