### PR TITLE
Enhancement of Censys test

### DIFF
--- a/services/sources/censys_test.go
+++ b/services/sources/censys_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/OWASP/Amass/resolvers"
 )
 
-func TestCensys(t *testing.T) {
+func TestCensysAPIRequest(t *testing.T) {
 	if *networkTest == false || *configPath == "" {
 		return
 	}
@@ -31,4 +31,35 @@ func TestCensys(t *testing.T) {
 	if result < expectedTest {
 		t.Errorf("Found %d names, expected at least %d instead", result, expectedTest)
 	}
+}
+
+func TestCensysWebRequest(t *testing.T) {
+	if *networkTest == false {
+		return
+	}
+
+	cfg := setupConfig(domainTest)
+
+	api := cfg.GetAPIKey("censys")
+
+	if api != nil {
+		api.Key = ""
+		api.Secret = ""		
+		cfg.AddAPIKey("censys",api)
+	}
+
+	bus, out := setupEventBus(requests.NewNameTopic)
+	defer bus.Stop()
+
+	pool := resolvers.NewResolverPool(nil)
+	defer pool.Stop()
+
+	srv := NewCensys(cfg, bus, pool)
+
+	result := testService(srv, out)
+	if result < expectedTest {
+		t.Errorf("Found %d names, expected at least %d instead", result, expectedTest)
+	}
+
+	
 }


### PR DESCRIPTION
This is a slight improvement of censys test. 
The test was only exploring the API request path so far whereas there is also a web request path if no API keys are provided.
This update allows to test the web request path.