### PR TITLE
examples(config.ini): fix typo

### DIFF
--- a/examples/config.ini
+++ b/examples/config.ini
@@ -58,7 +58,7 @@ port = 443
 #data_source = IPv4Info
 
 # Configure Amass to use a TinkerPop Server as the graph database
-# For an example of Gremlin seetings see: https://docs.microsoft.com/en-us/azure/cosmos-db/create-graph-gremlin-console
+# For an example of Gremlin settings see: https://docs.microsoft.com/en-us/azure/cosmos-db/create-graph-gremlin-console
 #[gremlin]
 #url = wss://localhost:8182
 #username =


### PR DESCRIPTION
`s/seetings/settings` in sample `config.ini`