### PR TITLE
net/dns: simplify RemoveAsteriskLabel function

### DIFF
--- a/net/dns/dns.go
+++ b/net/dns/dns.go
@@ -35,8 +35,12 @@ func CopyString(src string) string {
 
 // RemoveAsteriskLabel returns the provided DNS name with all asterisk labels removed.
 func RemoveAsteriskLabel(s string) string {
-	startIndex := strings.LastIndex(s, "*.") + 2
-	return s[startIndex:]
+	startIndex := strings.LastIndex(s, "*.")
+	if startIndex == -1 {
+		return s
+	}
+
+	return s[startIndex+2:]
 }
 
 // ReverseString returns the characters of the argument string in reverse order.

--- a/net/dns/dns.go
+++ b/net/dns/dns.go
@@ -35,19 +35,8 @@ func CopyString(src string) string {
 
 // RemoveAsteriskLabel returns the provided DNS name with all asterisk labels removed.
 func RemoveAsteriskLabel(s string) string {
-	var index int
-
-	labels := strings.Split(s, ".")
-	for i := len(labels) - 1; i >= 0; i-- {
-		if strings.TrimSpace(labels[i]) == "*" {
-			break
-		}
-		index = i
-	}
-	if index == len(labels)-1 {
-		return ""
-	}
-	return strings.Join(labels[index:], ".")
+	startIndex := strings.LastIndex(s, "*.") + 2
+	return s[startIndex:]
 }
 
 // ReverseString returns the characters of the argument string in reverse order.

--- a/net/dns/dns_test.go
+++ b/net/dns/dns_test.go
@@ -46,6 +46,8 @@ func TestRemoveAsteriskLabel(t *testing.T) {
 		{"Test 3: Subdomain-dashes", "*.sub-domain.owasp.org", "sub-domain.owasp.org"},
 		{"Test 4: Subdomain-dashes", "*.sub-d.sub-domain.owasp.org", "sub-d.sub-domain.owasp.org"},
 		{"Test 5: Middle Label Asterisk", "sub-d.sub-domain.*.owasp.org", "owasp.org"},
+		{"Test 6: Missing Asterisk Label", "sub-domain.owasp.org", "sub-domain.owasp.org"},
+		{"Test 7: Empty string", "", ""},
 	}
 	for _, tt := range tests {
 		s := RemoveAsteriskLabel(tt.event)

--- a/net/dns/dns_test.go
+++ b/net/dns/dns_test.go
@@ -45,6 +45,7 @@ func TestRemoveAsteriskLabel(t *testing.T) {
 		{"Test 2: Nested subdomain", "*.subdomain.owasp.org", "subdomain.owasp.org"},
 		{"Test 3: Subdomain-dashes", "*.sub-domain.owasp.org", "sub-domain.owasp.org"},
 		{"Test 4: Subdomain-dashes", "*.sub-d.sub-domain.owasp.org", "sub-d.sub-domain.owasp.org"},
+		{"Test 5: Middle Label Asterisk", "sub-d.sub-domain.*.owasp.org", "owasp.org"},
 	}
 	for _, tt := range tests {
 		s := RemoveAsteriskLabel(tt.event)


### PR DESCRIPTION
This PR simplifies the `RemoveAsteriskLabel` within the DNS utilities of Amass. To verify that no unintended behaviour was added, I ran the tests for this method and added the suggested test case too.

The original method is used in multiple places, so in my opinion simplifying it might be great for the project.

```console
➜ Amass git:(simplify-remove-asterisk-label) grep --exclude-dir=examples -Hrn "RemoveAsteriskLabel(" . | grep -v "_test.go"
./net/http/http.go:183:	commonName := dns.RemoveAsteriskLabel(cn)
./net/http/http.go:189:		n := dns.RemoveAsteriskLabel(name)
./net/dns/dns.go:37:func RemoveAsteriskLabel(s string) string {
./services/sources/crtsh.go:101:		names.Insert(dns.RemoveAsteriskLabel(result.Domain))
./services/sources/certspotter.go:96:					Name:   dns.RemoveAsteriskLabel(name),
./services/sources/entrust.go:120:		results = append(results, dns.RemoveAsteriskLabel(s))
./services/sources/censys.go:132:				n = dns.RemoveAsteriskLabel(n)
./services/sources/censys.go:175:			Name:   dns.RemoveAsteriskLabel(cleanName(sd)),
./services/namesrv.go:91:	req.Name = strings.ToLower(dns.RemoveAsteriskLabel(req.Name))
```

This PR is part of my Hacktoberfest work.
