### PR TITLE
net: simplify HexString

### DIFF
--- a/net/network.go
+++ b/net/network.go
@@ -5,6 +5,7 @@ package net
 
 import (
 	"bytes"
+	"encoding/hex"
 	"math/big"
 	"net"
 	"strings"
@@ -201,10 +202,5 @@ func IPv6NibbleFormat(ip string) string {
 
 // HexString returns a string that is the hex representation of the byte slice parameter.
 func HexString(b []byte) string {
-	hexDigit := "0123456789abcdef"
-	s := make([]byte, len(b)*2)
-	for i, tn := range b {
-		s[i*2], s[i*2+1] = hexDigit[tn>>4], hexDigit[tn&0xf]
-	}
-	return string(s)
+	return hex.EncodeToString(b)
 }


### PR DESCRIPTION
This PR simplifies the `HexString` function within the `net` utilities of Amass. It just uses the `hex` package provided by the standard library.

The places I identified where `HexString` is used are:
```console
./resolvers/resolver.go:265:		ptr = amassnet.IPv6NibbleFormat(amassnet.HexString(ip)) + ".ip6.arpa"
./resolvers/pool.go:274:		ptr = amassnet.IPv6NibbleFormat(amassnet.HexString(ip)) + ".ip6.arpa"
./services/sources/teamcymru.go:100:		name = amassnet.IPv6NibbleFormat(amassnet.HexString(ip)) + ".origin6.asn.cymru.com"
```

This PR is part of my Hacktoberfest work.