### PR TITLE
net: remove HexString function

### DIFF
--- a/net/network.go
+++ b/net/network.go
@@ -5,6 +5,7 @@ package net
 
 import (
 	"bytes"
+	"encoding/hex"
 	"math/big"
 	"net"
 	"strings"
@@ -201,10 +202,5 @@ func IPv6NibbleFormat(ip string) string {
 
 // HexString returns a string that is the hex representation of the byte slice parameter.
 func HexString(b []byte) string {
-	hexDigit := "0123456789abcdef"
-	s := make([]byte, len(b)*2)
-	for i, tn := range b {
-		s[i*2], s[i*2+1] = hexDigit[tn>>4], hexDigit[tn&0xf]
-	}
-	return string(s)
+	return hex.EncodeToString(b)
 }

--- a/net/network.go
+++ b/net/network.go
@@ -5,7 +5,6 @@ package net
 
 import (
 	"bytes"
-	"encoding/hex"
 	"math/big"
 	"net"
 	"strings"
@@ -198,9 +197,4 @@ func IPv6NibbleFormat(ip string) string {
 	}
 
 	return strings.Join(reversed, ".")
-}
-
-// HexString returns a string that is the hex representation of the byte slice parameter.
-func HexString(b []byte) string {
-	return hex.EncodeToString(b)
 }

--- a/resolvers/pool.go
+++ b/resolvers/pool.go
@@ -5,6 +5,7 @@ package resolvers
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"math/rand"
 	"net"
@@ -271,7 +272,7 @@ func (rp *ResolverPool) Reverse(ctx context.Context, addr string) (string, strin
 	if ip := net.ParseIP(addr); amassnet.IsIPv4(ip) {
 		ptr = amassnet.ReverseIP(addr) + ".in-addr.arpa"
 	} else if amassnet.IsIPv6(ip) {
-		ptr = amassnet.IPv6NibbleFormat(amassnet.HexString(ip)) + ".ip6.arpa"
+		ptr = amassnet.IPv6NibbleFormat(hex.EncodeToString(ip)) + ".ip6.arpa"
 	} else {
 		return ptr, "", &ResolveError{
 			Err:   fmt.Sprintf("Invalid IP address parameter: %s", addr),

--- a/resolvers/resolver.go
+++ b/resolvers/resolver.go
@@ -5,6 +5,7 @@ package resolvers
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"net"
 	"strings"
@@ -262,7 +263,7 @@ func (r *BaseResolver) Reverse(ctx context.Context, addr string) (string, string
 	if ip := net.ParseIP(addr); amassnet.IsIPv4(ip) {
 		ptr = amassnet.ReverseIP(addr) + ".in-addr.arpa"
 	} else if amassnet.IsIPv6(ip) {
-		ptr = amassnet.IPv6NibbleFormat(amassnet.HexString(ip)) + ".ip6.arpa"
+		ptr = amassnet.IPv6NibbleFormat(hex.EncodeToString(ip)) + ".ip6.arpa"
 	} else {
 		return ptr, "", &ResolveError{
 			Err:   fmt.Sprintf("Invalid IP address parameter: %s", addr),

--- a/services/sources/teamcymru.go
+++ b/services/sources/teamcymru.go
@@ -5,6 +5,7 @@ package sources
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"net"
 	"strconv"
@@ -97,7 +98,7 @@ func (t *TeamCymru) origin(addr string) *requests.ASNRequest {
 	if ip := net.ParseIP(addr); amassnet.IsIPv4(ip) {
 		name = amassnet.ReverseIP(addr) + ".origin.asn.cymru.com"
 	} else if amassnet.IsIPv6(ip) {
-		name = amassnet.IPv6NibbleFormat(amassnet.HexString(ip)) + ".origin6.asn.cymru.com"
+		name = amassnet.IPv6NibbleFormat(hex.EncodeToString(ip)) + ".origin6.asn.cymru.com"
 	} else {
 		t.Bus().Publish(requests.LogTopic,
 			fmt.Sprintf("%s: %s: Failed to parse the IP address", t.String(), addr),


### PR DESCRIPTION
This PR removes the HexString function within the net utilities of Amass. It just uses the hex package provided by the standard library in the places where the old function was used.

The places I identified where HexString was used are:

```
./resolvers/resolver.go:265:		ptr = amassnet.IPv6NibbleFormat(amassnet.HexString(ip)) + ".ip6.arpa"
./resolvers/pool.go:274:		ptr = amassnet.IPv6NibbleFormat(amassnet.HexString(ip)) + ".ip6.arpa"
./services/sources/teamcymru.go:100:		name = amassnet.IPv6NibbleFormat(amassnet.HexString(ip)) + ".origin6.asn.cymru.com"
```

This PR is part of my Hacktoberfest work.