### PR TITLE
Fix ptrarchive source

### DIFF
--- a/services/ptrarchive.go
+++ b/services/ptrarchive.go
@@ -63,7 +63,6 @@ func (p *PTRArchive) OnDNSRequest(ctx context.Context, req *requests.DNSRequest)
 	bus.Publish(requests.SetActiveTopic, p.String())
 
 	v := url.Values{}
-	v.Set("name", "Ava")
 
 	dial := net.Dialer{}
 	client := &outhttp.Client{

--- a/services/ptrarchive_test.go
+++ b/services/ptrarchive_test.go
@@ -5,6 +5,8 @@ package services
 
 import (
 	"testing"
+	
+	"github.com/OWASP/Amass/net/http"
 )
 
 func TestPTRArchive(t *testing.T) {
@@ -15,5 +17,25 @@ func TestPTRArchive(t *testing.T) {
 	result := testDNSRequest("PTRArchive")
 	if result < expectedTest {
 		t.Errorf("Found %d names, expected at least %d instead", result, expectedTest)
+	}
+}
+
+func TestPTRArchiveEndpoint(t *testing.T) {
+	if *networkTest == false {
+		return
+	}
+
+	var endpoint string
+	var ptr *PTRArchive
+	var err error
+
+
+	ptr = NewPTRArchive(testSystem)
+	endpoint = ptr.getURL(domainTest)
+
+	_, err = http.RequestWebPage(endpoint, nil, nil, "", "")
+
+	if err.Error() == "404 Not Found" {
+		t.Errorf("ptr Web API's name has changed: %s", endpoint)
 	}
 }

--- a/services/ptrarchive_test.go
+++ b/services/ptrarchive_test.go
@@ -35,7 +35,9 @@ func TestPTRArchiveEndpoint(t *testing.T) {
 
 	_, err = http.RequestWebPage(endpoint, nil, nil, "", "")
 
-	if err.Error() == "404 Not Found" {
-		t.Errorf("ptr Web API's name has changed: %s", endpoint)
+	if err != nil {
+		if err.Error() == "404 Not Found" {
+			t.Errorf("ptr Web API's name has changed: %s", endpoint)
+		}
 	}
 }


### PR DESCRIPTION
The ptrarchive source was not working anymore for two reasons:

1. The endpoint name changed
I updated the endpoint name and added a check to get notified in the future if the endpoint changed.

2. A restriction was set to check whether the request is coming from an automation
I added a fake cookie in the request we send. This bypasses the check done by the domain we're reaching.

Result:
```
go test -run PTRArchive -network=true
PASS
ok      github.com/OWASP/Amass/services 6.369s
```

Question:

In TestPTRArchiveEndpoint(), I'm matching the error with a string. I'm not a big fan of this method.
Should I create a custom 404 error instead ? 

Thanks