### PR TITLE
Split -include-unresolvable into -unresolvable and -nowildcard

### DIFF
--- a/cmd/amass/enum.go
+++ b/cmd/amass/enum.go
@@ -71,7 +71,7 @@ type enumArgs struct {
 		ScoreResolvers      bool
 		Sources             bool
 		NoWildcard          bool
-		IncludeUnresolved   bool
+		Unresolved          bool
 		Verbose             bool
 	}
 	Filepaths struct {
@@ -125,7 +125,7 @@ func defineEnumOptionFlags(enumFlags *flag.FlagSet, args *enumArgs) {
 	enumFlags.BoolVar(&args.Options.ScoreResolvers, "noresolvscore", true, "Disable resolver reliability scoring")
 	enumFlags.BoolVar(&args.Options.Sources, "src", false, "Print data sources for the discovered names")
 	enumFlags.BoolVar(&args.Options.NoWildcard, "nowildcard", false, "Turn off wildcard detection")
-	enumFlags.BoolVar(&args.Options.IncludeUnresolved, "include-unresolvable", false, "Output DNS names that did not resolve")
+	enumFlags.BoolVar(&args.Options.Unresolved, "include-unresolvable", false, "Output DNS names that did not resolve")
 	enumFlags.BoolVar(&args.Options.Verbose, "v", false, "Output status / debug / troubleshooting info")
 }
 
@@ -572,7 +572,7 @@ func (e enumArgs) OverrideConfig(conf *config.Config) error {
 	if e.Options.NoWildcard {
 		conf.NoWildcard = true
 	}
-	if e.Options.IncludeUnresolved {
+	if e.Options.Unresolved {
 		conf.IncludeUnresolvable = true
 	}
 	if e.Options.Passive {

--- a/cmd/amass/enum.go
+++ b/cmd/amass/enum.go
@@ -71,7 +71,7 @@ type enumArgs struct {
 		ScoreResolvers      bool
 		Sources             bool
 		NoWildcard          bool
-		Unresolved          bool
+		IncludeUnresolved   bool
 		Verbose             bool
 	}
 	Filepaths struct {
@@ -125,7 +125,7 @@ func defineEnumOptionFlags(enumFlags *flag.FlagSet, args *enumArgs) {
 	enumFlags.BoolVar(&args.Options.ScoreResolvers, "noresolvscore", true, "Disable resolver reliability scoring")
 	enumFlags.BoolVar(&args.Options.Sources, "src", false, "Print data sources for the discovered names")
 	enumFlags.BoolVar(&args.Options.NoWildcard, "nowildcard", false, "Turn off wildcard detection")
-	enumFlags.BoolVar(&args.Options.Unresolved, "unresolvable", false, "Output DNS names that did not resolve")
+	enumFlags.BoolVar(&args.Options.IncludeUnresolved, "include-unresolvable", false, "Output DNS names that did not resolve")
 	enumFlags.BoolVar(&args.Options.Verbose, "v", false, "Output status / debug / troubleshooting info")
 }
 
@@ -325,7 +325,7 @@ func processEnumOutput(e *enum.Enumeration, args *enumArgs) {
 		// Collect all the names returned by the enumeration
 		for out := range e.Output {
 			out.Addresses = format.DesiredAddrTypes(out.Addresses, args.Options.IPv4, args.Options.IPv6)
-			if !e.Config.Passive && !e.Config.Unresolvable && len(out.Addresses) <= 0 {
+			if !e.Config.Passive && !e.Config.IncludeUnresolvable && len(out.Addresses) <= 0 {
 				continue
 			}
 
@@ -572,8 +572,8 @@ func (e enumArgs) OverrideConfig(conf *config.Config) error {
 	if e.Options.NoWildcard {
 		conf.NoWildcard = true
 	}
-	if e.Options.Unresolved {
-		conf.Unresolvable = true
+	if e.Options.IncludeUnresolved {
+		conf.IncludeUnresolvable = true
 	}
 	if e.Options.Passive {
 		conf.Passive = true

--- a/config/config.go
+++ b/config/config.go
@@ -115,7 +115,7 @@ type Config struct {
 	NoWildcard bool `ini:"no-wildcard"`
 
 	// Determines if unresolved DNS names will be output by the enumeration
-	IncludeUnresolvable bool `ini:"include-unresolvable"`
+	IncludeUnresolvable bool `ini:"include_unresolvable"`
 
 	// A blacklist of subdomain names that will not be investigated
 	Blacklist []string

--- a/config/config.go
+++ b/config/config.go
@@ -115,7 +115,7 @@ type Config struct {
 	NoWildcard bool `ini:"no-wildcard"`
 
 	// Determines if unresolved DNS names will be output by the enumeration
-	Unresolvable bool `ini:"unresolvable"`
+	IncludeUnresolvable bool `ini:"include-unresolvable"`
 
 	// A blacklist of subdomain names that will not be investigated
 	Blacklist []string

--- a/config/config.go
+++ b/config/config.go
@@ -111,8 +111,11 @@ type Config struct {
 	// Determines if zone transfers will be attempted
 	Active bool
 
+	// Determines if wildcard detection should be performed
+	NoWildcard bool `ini:"no-wildcard"`
+
 	// Determines if unresolved DNS names will be output by the enumeration
-	IncludeUnresolvable bool `ini:"include_unresolvable"`
+	Unresolvable bool `ini:"unresolvable"`
 
 	// A blacklist of subdomain names that will not be investigated
 	Blacklist []string

--- a/enum/names.go
+++ b/enum/names.go
@@ -74,7 +74,7 @@ func (e *Enumeration) newResolvedName(req *requests.DNSRequest) {
 	}
 
 	// Put the DNS name + records on the queue for output processing
-	if e.hasARecords(req) {
+	if e.hasARecords(req) || e.Config.Unresolvable {
 		e.resolvedQueue.Append(req)
 	}
 

--- a/enum/names.go
+++ b/enum/names.go
@@ -74,7 +74,7 @@ func (e *Enumeration) newResolvedName(req *requests.DNSRequest) {
 	}
 
 	// Put the DNS name + records on the queue for output processing
-	if e.hasARecords(req) || e.Config.Unresolvable {
+	if e.Config.IncludeUnresolvable || e.hasARecords(req) {
 		e.resolvedQueue.Append(req)
 	}
 

--- a/requests/request.go
+++ b/requests/request.go
@@ -63,11 +63,11 @@ type DNSAnswer struct {
 
 // DNSRequest handles data needed throughout Service processing of a DNS name.
 type DNSRequest struct {
-	Name    string
-	Domain  string
-	Records []DNSAnswer
-	Tag     string
-	Source  string
+	Name    string      `json:"name"`
+	Domain  string      `json:"domain"`
+	Records []DNSAnswer `json:"records"`
+	Tag     string      `json:"tag"`
+	Source  string      `json:"source"`
 }
 
 // AddrRequest handles data needed throughout Service processing of a network address.

--- a/services/dnssrv.go
+++ b/services/dnssrv.go
@@ -86,7 +86,7 @@ func (ds *DNSService) processDNSRequest(ctx context.Context, req *requests.DNSRe
 	req.Records = answers
 	if len(req.Records) == 0 {
 		// Check if this unresolved name should be output by the enumeration
-		if cfg.Unresolvable && cfg.IsDomainInScope(req.Name) {
+		if cfg.IncludeUnresolvable && cfg.IsDomainInScope(req.Name) {
 			bus.Publish(requests.OutputTopic, &requests.Output{
 				Name:   req.Name,
 				Domain: req.Domain,


### PR DESCRIPTION
The -include-unresolvable option did not list names falling under wildcards and due to a missed check didn't let names without an A record to be printed in the output.

This patch introduces 2 new flags -unresolvable and -nowildcard to logically split the inclusion of unresolvable names and the wildcard detection support, respectively.

It also provides JSON tagging to the DNSRequest struct that could be useful to customizations of the amass codebase.