### PR TITLE
net/http: fix dropped error

### DIFF
--- a/net/http/http.go
+++ b/net/http/http.go
@@ -118,7 +118,7 @@ func RequestWebPage(urlstring string, body io.Reader, hvals map[string]string, u
 
 	in, err := ioutil.ReadAll(resp.Body)
 	resp.Body.Close()
-	return string(in), nil
+	return string(in), err
 }
 
 // PullCertificateNames attempts to pull a cert from one or more ports on an IP.


### PR DESCRIPTION
This fixes a dropped error variable in the `net/http` package.