### PR TITLE
services: Prune Unused Code

### DIFF
--- a/services/dnssrv.go
+++ b/services/dnssrv.go
@@ -254,31 +254,6 @@ func (ds *DNSService) attemptZoneXFR(ctx context.Context, sub, domain, server st
 	}
 }
 
-func (ds *DNSService) attemptZoneWalk(ctx context.Context, domain, server string) {
-	cfg := ctx.Value(requests.ContextConfig).(*config.Config)
-	bus := ctx.Value(requests.ContextEventBus).(*eventbus.EventBus)
-	if cfg == nil || bus == nil {
-		return
-	}
-
-	addr, err := ds.nameserverAddr(ctx, server)
-	if addr == "" {
-		bus.Publish(requests.LogTopic, eventbus.PriorityHigh, fmt.Sprintf("DNS: Zone Walk failed: %v", err))
-		return
-	}
-
-	reqs, err := resolvers.NsecTraversal(domain, addr)
-	if err != nil {
-		bus.Publish(requests.LogTopic, eventbus.PriorityHigh,
-			fmt.Sprintf("DNS: Zone Walk failed: %s: %v", server, err))
-		return
-	}
-
-	for _, req := range reqs {
-		ds.DNSRequest(ctx, req)
-	}
-}
-
 func (ds *DNSService) nameserverAddr(ctx context.Context, server string) (string, error) {
 	a, _, err := ds.System().Pool().Resolve(ctx, server, "A", resolvers.PriorityHigh)
 	if err != nil {

--- a/services/local.go
+++ b/services/local.go
@@ -6,7 +6,6 @@ package services
 import (
 	"errors"
 	"sync"
-	"time"
 
 	"github.com/OWASP/Amass/v3/config"
 	"github.com/OWASP/Amass/v3/graph"
@@ -190,20 +189,4 @@ func (l *LocalSystem) initCoreServices() error {
 	}
 
 	return nil
-}
-
-func (l *LocalSystem) periodicChecks() {
-	t := time.NewTicker(10 * time.Second)
-	defer t.Stop()
-
-	for {
-		select {
-		case <-l.done:
-			return
-		case <-t.C:
-			if a, err := l.Pool().Available(); !a && err != nil {
-				l.Config().Log.Print(err.Error())
-			}
-		}
-	}
 }

--- a/services/radb.go
+++ b/services/radb.go
@@ -25,11 +25,6 @@ const (
 	radbWhoisURL = "whois.radb.net"
 )
 
-var (
-	// radbRegistries are all the registries that have RADb servers
-	radbRegistries = []string{"arin", "ripencc", "apnic", "lacnic", "afrinic"}
-)
-
 // RADb is the Service that handles access to the RADb data source.
 type RADb struct {
 	BaseService


### PR DESCRIPTION
This removes unused an unused variable and functions from the `services` package.

I can squash this into a single commit, if you prefer.