### PR TITLE
Bug fix: Rate limiting sleep duration miscomputed

### DIFF
--- a/services/service.go
+++ b/services/service.go
@@ -255,7 +255,7 @@ func (bas *BaseService) CheckRateLimit() {
 	defer bas.lastLock.Unlock()
 
 	if delta := time.Now().Sub(bas.last); bas.rateLimit > delta {
-		time.Sleep(delta)
+		time.Sleep(bas.rateLimit - delta)
 	}
 	bas.last = time.Now()
 }


### PR DESCRIPTION
This change fixes a bug that was reported to me concerning our service rate limiting handler.

For any service, we wait for a certain delay (related to the service rate limit) before firing a new request. Here, the rate limit was not properly computed. Instead of waiting until the rate limit duration passes, we were waiting for the amount of time that passed since our last call.