### PR TITLE
Prune Services Redux

### DIFF
--- a/services/local.go
+++ b/services/local.go
@@ -6,7 +6,6 @@ package services
 import (
 	"errors"
 	"sync"
-	"time"
 
 	"github.com/OWASP/Amass/v3/config"
 	"github.com/OWASP/Amass/v3/graph"
@@ -190,20 +189,4 @@ func (l *LocalSystem) initCoreServices() error {
 	}
 
 	return nil
-}
-
-func (l *LocalSystem) periodicChecks() {
-	t := time.NewTicker(10 * time.Second)
-	defer t.Stop()
-
-	for {
-		select {
-		case <-l.done:
-			return
-		case <-t.C:
-			if a, err := l.Pool().Available(); !a && err != nil {
-				l.Config().Log.Print(err.Error())
-			}
-		}
-	}
 }

--- a/services/radb.go
+++ b/services/radb.go
@@ -25,11 +25,6 @@ const (
 	radbWhoisURL = "whois.radb.net"
 )
 
-var (
-	// radbRegistries are all the registries that have RADb servers
-	radbRegistries = []string{"arin", "ripencc", "apnic", "lacnic", "afrinic"}
-)
-
 // RADb is the Service that handles access to the RADb data source.
 type RADb struct {
 	BaseService


### PR DESCRIPTION
This prunes an unused function and an unused variable from the `services` package, replacing https://github.com/OWASP/Amass/pull/365.