### PR TITLE
Set UDP size in EDNS0_SUBNET option

### DIFF
--- a/resolvers/msgs.go
+++ b/resolvers/msgs.go
@@ -58,6 +58,7 @@ func setupOptions() *dns.OPT {
 		Hdr: dns.RR_Header{
 			Name:   ".",
 			Rrtype: dns.TypeOPT,
+			Class:  dns.DefaultMsgSize,
 		},
 		Option: []dns.EDNS0{e},
 	}


### PR DESCRIPTION
Set UDP payload size when making DNS queries (before was `0`, now `4096`). Finally, Amass doesn't fail when run through VPN. Fixes https://github.com/OWASP/Amass/issues/253 