### PR TITLE
Add system config file fallback

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -266,8 +267,17 @@ func AcquireConfig(dir, file string, cfg *Config) error {
 	} else if f, set := os.LookupEnv("AMASS_CONFIG"); set {
 		path = f
 	} else if d := OutputDirectory(dir); d != "" {
-		if finfo, err := os.Stat(d); !os.IsNotExist(err) && finfo.IsDir() {
-			path = filepath.Join(d, "config.ini")
+		var path_candidate = filepath.Join(d, "config.ini")
+		if _, err := os.Stat(path_candidate); err == nil {
+			path = path_candidate
+		}
+	}
+
+	// On Unix systems, fallback on system config directory
+	if path == "" && runtime.GOOS != "windows" {
+		var path_candidate = "/etc/amass/config.ini"
+		if _, err := os.Stat(path_candidate); err == nil {
+			path = path_candidate
 		}
 	}
 

--- a/doc/user_guide.md
+++ b/doc/user_guide.md
@@ -212,7 +212,7 @@ Amass automatically tries to discover the configuration file (named `config.ini`
 
 | Operating System | Path |
 | ---------------- | ---- |
-| Linux / Unix | `$XDG_CONFIG_HOME/amass/config.ini` or `$HOME/.config/amass/config.ini` |
+| Linux / Unix | `$XDG_CONFIG_HOME/amass/config.ini` or `$HOME/.config/amass/config.ini` or `/etc/amass/config.ini` |
 | Windows | `%AppData%\amass\config.ini` |
 | OSX | `$HOME/Library/Application Support/amass/config.ini` |
 


### PR DESCRIPTION
This adds a fallback on `/etc/amass/config.ini` on Unix systems if config file can not be found elsewhere.

The rationale is that we use Amass on headless multi user boxes, so it makes sense to have a common system wide config if users have none in their home.