### PR TITLE
amass: instruct Go toolchain to replace a broken dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,3 +48,5 @@ require (
 	gopkg.in/ini.v1 v1.61.0 // indirect
 	layeh.com/gopher-json v0.0.0-20190114024228-97fed8db8427
 )
+
+replace github.com/knq/sysutil v1.0.0 => github.com/chromedp/sysutil v1.0.0


### PR DESCRIPTION
As per the most recent release of Amass Go module (v3.10.5), it depends on a module that was transferred to a new location.

```console
$ go mod why github.com/knq/sysutil
github.com/OWASP/Amass/v3/net/http
github.com/geziyor/geziyor/client
github.com/chromedp/cdproto/dom
github.com/chromedp/cdproto/cdp
github.com/knq/sysutil
```

Amass depends on github.com/geziyor/geziyor/client and one of its transitive dependencies depends on github.com/knq/sysutil, which was transferred to github.com/chromedp/cdproto/sysutil.

As long as there's no new version tagged for https://github.com/geziyor/geziyor and Amass starts using it, the only way to fix this issue is to instruct the Go toolchain to replace the sysutil module location with its new home.

Fixes #500

---

Proposal: It would be nice if you could tag a new release after merging this change so people can import recent Amass module versions again.
