### PR TITLE
[OPINION] Remove TXT from the DNS record types

### DIFF
--- a/enum/dns.go
+++ b/enum/dns.go
@@ -20,7 +20,6 @@ import (
 // InitialQueryTypes include the DNS record types that are queried for a discovered name.
 var InitialQueryTypes = []uint16{
 	dns.TypeCNAME,
-	dns.TypeTXT,
 	dns.TypeA,
 	dns.TypeAAAA,
 }


### PR DESCRIPTION
I don't TXT record is a thing worth to check, since SPF servers also have an IP address (`A` record)!! Remove this will increase the speed a lot!