### PR TITLE
More file extensions + decode response content + small updates

### DIFF
--- a/net/http/http.go
+++ b/net/http/http.go
@@ -41,15 +41,16 @@ const (
 	// AcceptLang is the default HTTP Accept-Language header value used by Amass.
 	AcceptLang = "en-US,en;q=0.8"
 
-	httpTimeout      = 3 * time.Minute
+	httpTimeout      = 30 * time.Second
 	handshakeTimeout = 5 * time.Second
 )
 
 var (
-	subRE          = dns.AnySubdomainRegex()
-	crawlRE        = regexp.MustCompile(`\.\w{3,4}($|\?)`)
-	crawlFileTypes = []string{".html", ".htm", "xhtml", ".js", ".php"}
-	nameStripRE    = regexp.MustCompile(`^u[0-9a-f]{4}|20|22|25|2b|2f|3d|3a|40`)
+	subRE           = dns.AnySubdomainRegex()
+	crawlRE         = regexp.MustCompile(`\.[a-z0-9]{2,6}($|\?|#)`)
+	crawlFileStarts = []string{"js", "htm", "as", "php", "inc"}
+	crawlFileEnds   = []string{"html", "do", "action", "cgi"}
+	nameStripRE     = regexp.MustCompile(`^u[0-9a-f]{4}|20|22|25|2b|2f|3d|3a|40`)
 )
 
 // DefaultClient is the same HTTP client used by the package methods.
@@ -133,7 +134,11 @@ func RequestWebPage(ctx context.Context, u string, body io.Reader, hvals map[str
 	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
 		err = errors.New(resp.Status)
 	}
-	return string(in), err
+	content, err := url.QueryUnescape(string(in))
+	if err != nil {
+		content = string(in)
+	}
+	return content, err
 }
 
 // Crawl will spider the web page at the URL argument looking for DNS names within the scope argument.
@@ -164,7 +169,7 @@ func Crawl(ctx context.Context, u string, scope []string, max int, filter string
 	g := geziyor.NewGeziyor(&geziyor.Options{
 		AllowedDomains:        newScope,
 		StartURLs:             []string{u},
-		Timeout:               5 * time.Minute,
+		Timeout:               30 * time.Second,
 		RobotsTxtDisabled:     true,
 		UserAgent:             UserAgent,
 		LogDisabled:           true,
@@ -172,7 +177,11 @@ func Crawl(ctx context.Context, u string, scope []string, max int, filter string
 		RequestDelay:          750 * time.Millisecond,
 		RequestDelayRandomize: true,
 		ParseFunc: func(g *geziyor.Geziyor, r *client.Response) {
-			for _, n := range subRE.FindAllString(string(r.Body), -1) {
+			body, err := url.QueryUnescape(string(r.Body))
+			if err != nil {
+				body = string(r.Body)
+			}
+			for _, n := range subRE.FindAllString(body, -1) {
 				if name := CleanName(n); whichDomain(name, scope) != "" {
 					m.Lock()
 					results.Insert(name)
@@ -194,11 +203,17 @@ func Crawl(ctx context.Context, u string, scope []string, max int, filter string
 					}
 					// If the URL path has a file extension, check that it's of interest
 					if ext := crawlRE.FindString(p.Path); ext != "" {
-						ext = strings.ToLower(ext)
+						ext = strings.TrimRight(ext, "?#")
 
 						var found bool
-						for _, t := range crawlFileTypes {
-							if ext == t {
+						for _, s := range crawlFileStarts {
+							if strings.HasPrefix(ext, "." + s) {
+								found = true
+								break
+							}
+						}
+						for _, e := range crawlFileEnds {
+							if strings.HasSuffix(ext, e) {
 								found = true
 								break
 							}

--- a/resources/scripts/archive/wayback.ads
+++ b/resources/scripts/archive/wayback.ads
@@ -34,11 +34,11 @@ function vertical(ctx, domain)
         end
     end
     
-    sendnames(ctx, resp)
+    sendnames(ctx, decode(resp))
 end
 
 function buildurl(domain)
-    return "http://web.archive.org/cdx/search/cdx?url=*." .. domain .. "&output=json&collapse=urlkey"
+    return "http://web.archive.org/cdx/search/cdx?matchType=domain&fl=original&output=json&collapse=urlkey&url=" .. domain
 end
 
 function sendnames(ctx, content)

--- a/resources/scripts/archive/wayback.ads
+++ b/resources/scripts/archive/wayback.ads
@@ -34,7 +34,7 @@ function vertical(ctx, domain)
         end
     end
     
-    sendnames(ctx, decode(resp))
+    sendnames(ctx, resp)
 end
 
 function buildurl(domain)


### PR DESCRIPTION
- Reduced the request timeout (from extra 3 minutes to 30 seconds)
- Added more interesting file extensions (using "starts with" and "ends with" for a wide range of good extensions, like: ***as**p*, ***as**hx*, ...)
- Decoding the response body. While I was using Amass, I notified some `80www.domain.com`, `2fsub.domain.com` (probably because of `href=https://domain.com/login?next=http%3A%2F%2Fsub.domain.com`), or even `%2e.xoom.com` (from `AlienVault`).
- Update the WayBackMachine request URL. With `fl=original`, the response size will be reduced by more than a half! (Normally, a request to WayBackMachine will receive a really huge data, which tortures the CPU. But the current URL returns a lot of useless information like: content-type, status-code, id, ...)