### PR TITLE
Update user_guide.md

### DIFF
--- a/doc/user_guide.md
+++ b/doc/user_guide.md
@@ -107,7 +107,6 @@ This subcommand will perform DNS enumeration and network mapping while populatin
 | -demo | Censor output to make it suitable for demonstrations | amass enum -demo -d example.com |
 | -df | Path to a file providing root domain names | amass enum -df domains.txt |
 | -dir | Path to the directory containing the graph database | amass enum -dir PATH -d example.com |
-| -do | Path to data operations output file | amass enum -do data.json -d example.com |
 | -ef | Path to a file providing data sources to exclude | amass enum -ef exclude.txt -d example.com |
 | -exclude | Data source names separated by commas to be excluded | amass enum -exclude crtsh -d example.com |
 | -if | Path to a file providing data sources to include | amass enum -if include.txt -d example.com |


### PR DESCRIPTION
*** Removal of the redundant -do flag of the enum subcommand. ***

HOW IT STARTED
The -do flag for the enum subcommand seems to be given an error "flag provided but not defined: -do," or am I doing something wrong? I believe the following syntax is correct: amass enum -do data.json -d example.com. Please help!

There's no -do flag. You can obtain the JSON file by either pulling it from the output directory (e.x. on Linux: ~/.config/amass/amass.JSON) or using the following command once your enumeration has finished: amass db -json amass.json -d domain.com.

Thanks as always. Do we then need to remove the item illustrated in the screenshot as seen on the user guide?

Yes. Are you interested in sending the PR?

Yes, I would.