### PR TITLE
Support the AS prefix in ASNs

### DIFF
--- a/cmd/amass/intel.go
+++ b/cmd/amass/intel.go
@@ -33,7 +33,7 @@ const (
 
 type intelArgs struct {
 	Addresses        format.ParseIPs
-	ASNs             format.ParseInts
+	ASNs             format.ParseASNs
 	CIDRs            format.ParseCIDRs
 	OrganizationName string
 	Domains          stringset.Set

--- a/format/parse.go
+++ b/format/parse.go
@@ -25,6 +25,9 @@ type ParseIPs []net.IP
 // ParseCIDRs implements the flag.Value interface.
 type ParseCIDRs []*net.IPNet
 
+// ParseASNs implements the flag.Value interface.
+type ParseASNs []int
+
 func (p *ParseStrings) String() string {
 	if p == nil {
 		return ""
@@ -168,6 +171,37 @@ func (p *ParseCIDRs) Set(s string) error {
 		}
 
 		*p = append(*p, ipnet)
+	}
+	return nil
+}
+
+func (p *ParseASNs) String() string {
+	if p == nil {
+		return ""
+	}
+	var builder strings.Builder
+	for i, n := range *p {
+		if i > 0 {
+			builder.WriteRune(',')
+		}
+		builder.WriteString(strconv.Itoa(n))
+	}
+	return builder.String()
+}
+
+// Set implements the flag.Value interface.
+func (p *ParseASNs) Set(s string) error {
+	if s == "" {
+		return fmt.Errorf("ASN parsing failed")
+	}
+
+	asns := strings.Split(s, ",")
+	for _, asn := range asns {
+		i, err := strconv.Atoi(strings.TrimPrefix(strings.TrimSpace(asn), "AS"))
+		if err != nil {
+			return err
+		}
+		*p = append(*p, i)
 	}
 	return nil
 }

--- a/format/parse_test.go
+++ b/format/parse_test.go
@@ -267,3 +267,52 @@ func TestParseCIDRs(t *testing.T) {
 		t.Run(c.label, f)
 	}
 }
+
+func TestParseASNs(t *testing.T) {
+	cases := []struct {
+		label string
+		input string
+		ok    bool
+		want  string
+	}{
+		{
+			label: "empty",
+			input: "",
+		}, {
+			label: "valid ASNs with and without AS prefix",
+			input: "AS1234,AS4567,7777",
+			ok:    true,
+			want:  "1234,4567,7777",
+		}, {
+			label: "invalid ASN",
+			input: "AS1234,4567,ASABC",
+		}, {
+			label: "whitespace",
+			input: "\tAS1234 , 4567 ",
+			ok:    true,
+			want:  "1234,4567",
+		}, {
+			label: "extraneous comma",
+			input: "AS1234,",
+		},
+	}
+	for _, c := range cases {
+		f := func(t *testing.T) {
+			var asns ParseASNs
+			err := asns.Set(c.input)
+			if err != nil && c.ok {
+				t.Errorf("got %v; want <nil>", err)
+			}
+			if err == nil && !c.ok {
+				t.Error("got <nil>; want some error")
+			}
+			if err == nil && c.ok {
+				got := asns.String()
+				if got != c.want {
+					t.Errorf("got %q; want %q", got, c.want)
+				}
+			}
+		}
+		t.Run(c.label, f)
+	}
+}


### PR DESCRIPTION
ASNs are often displayed in the `AS####` format in various sources and currently Amass only supports integers in the `amass intel -asn <ASN>` command. Because of that I have to delete 2 characters from my input and that's too much work ;)

This PR adds support for `AS` prefix.

And while I'm here thanks for the great tool!