### PR TITLE
Store Enumeration context as soon as possible on Start

### DIFF
--- a/enum/enum.go
+++ b/enum/enum.go
@@ -90,10 +90,11 @@ func (e *Enumeration) Start(ctx context.Context) error {
 	if err := e.Config.CheckSettings(); err != nil {
 		return err
 	}
+	e.setupContext(ctx)
 
 	// The pipeline input source will receive all the names
 	e.nameSrc = newEnumSource(e, maxInputSourceBuffer)
-	e.startupAndCleanup(ctx)
+	e.startupAndCleanup()
 	defer e.stop()
 
 	var stages []pipeline.Stage
@@ -131,7 +132,7 @@ func (e *Enumeration) Start(ctx context.Context) error {
 	return pipeline.NewPipeline(stages...).Execute(e.ctx, e.nameSrc, e.makeOutputSink())
 }
 
-func (e *Enumeration) startupAndCleanup(ctx context.Context) {
+func (e *Enumeration) startupAndCleanup() {
 	/*
 	 * These events are important to the engine in order to receive data,
 	 * logs, and notices about discoveries made during the enumeration
@@ -143,7 +144,6 @@ func (e *Enumeration) startupAndCleanup(ctx context.Context) {
 		e.Bus.Subscribe(requests.NewASNTopic, e.Sys.Cache().Update)
 	}
 
-	e.setupContext(ctx)
 	go e.periodicLogging()
 
 	go func() {


### PR DESCRIPTION
This commit addresses a race condition that exists when starting an enumeration. In `(*enumSource).checkForData`, one case of the select statement depends on `(*Enumeration).ctx`, which gets set in a function called after the goroutine which depends on it has already started, creating a race which may end in a segmentation fault.

By setting the Context field as soon as possible when starting an enumeration, we avoid this race entirely.

Addresses https://github.com/OWASP/Amass/issues/627