### PR TITLE
Optimized Archive-It data source

### DIFF
--- a/resources/scripts/archive/archiveit.ads
+++ b/resources/scripts/archive/archiveit.ads
@@ -11,8 +11,8 @@ function start()
 end
 
 function vertical(ctx, domain)
-    for i=1,25,1 do
-        local ok = scrape(ctx, {['url']=buildurl(domain, i)})
+    for i=1,25 do
+        local ok = scrape(ctx, {['url']=firsturl(domain, i)})
         if not ok then
             break
         end
@@ -21,11 +21,19 @@ function vertical(ctx, domain)
     end
 end
 
-function buildurl(domain, pagenum)
+function resolved(ctx, name, domain, records)
+    crawl(ctx, secondurl(domain), 5)
+end
+
+function firsturl(domain, pagenum)
     local params = {
         show="Sites",
         q=domain,
         page=pagenum,
     }
     return "https://archive-it.org/explore?" .. url.build_query_string(params)
+end
+
+function secondurl(domain)
+    return "https://wayback.archive-it.org/all/*/https://" .. domain
 end

--- a/resources/scripts/archive/archiveit.ads
+++ b/resources/scripts/archive/archiveit.ads
@@ -22,7 +22,11 @@ function vertical(ctx, domain)
 end
 
 function resolved(ctx, name, domain, records)
-    crawl(ctx, secondurl(domain), 5)
+    local page, err = request({['url']=secondurl(domain)})
+    if (err ~= nil and err ~= "") then
+        return
+    end
+    crawl(ctx, secondurl(domain), 3)
 end
 
 function firsturl(domain, pagenum)

--- a/resources/scripts/archive/archiveit.ads
+++ b/resources/scripts/archive/archiveit.ads
@@ -9,15 +9,8 @@ function start()
 end
 
 function vertical(ctx, domain)
-    scrape(ctx, {['url']=firsturl(domain)})
-
-    local found = pages(ctx, domain)
-    if not found then
-        return
-    end
-
-    for i=1,50,1 do
-        local ok = scrape(ctx, {['url']=secondurl(domain, i)})
+    for i=1,25,1 do
+        local ok = scrape(ctx, {['url']=buildurl(domain, i)})
         if not ok then
             break
         end
@@ -26,25 +19,6 @@ function vertical(ctx, domain)
     end
 end
 
-function firsturl(domain)
-    return "https://wayback.archive-it.org/all/timemap/cdx?matchType=domain&fl=original&collapse=urlkey&url=" .. domain
-end
-
-function secondurl(domain, pagenum)
+function buildurl(domain, pagenum)
     return "https://archive-it.org/explore?show=Sites&q=" .. domain .. "&page=" .. pagenum
-end
-
-function pages(ctx, domain)
-    local u = "https://archive-it.org/explore?show=Sites&q=" .. domain
-    local resp, err = request(ctx, {['url']=u})
-    if (err ~= nil and err ~= "") then
-        return false
-    end
-
-    local match = find(resp, "No metadata results")
-    if (match == nil or #match == 0) then
-        return false
-    end
-
-    return true
 end

--- a/resources/scripts/archive/archiveit.ads
+++ b/resources/scripts/archive/archiveit.ads
@@ -1,6 +1,8 @@
 -- Copyright 2017-2021 Jeff Foley. All rights reserved.
 -- Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
+local url = require("url")
+
 name = "ArchiveIt"
 type = "archive"
 
@@ -20,5 +22,10 @@ function vertical(ctx, domain)
 end
 
 function buildurl(domain, pagenum)
-    return "https://archive-it.org/explore?show=Sites&q=" .. domain .. "&page=" .. pagenum
+    local params = {
+        show="Sites",
+        q=domain,
+        page=pagenum,
+    }
+    return "https://archive-it.org/explore?" .. url.build_query_string(params)
 end


### PR DESCRIPTION
Since Archive-It `cdx` API query returns the same thing as `Wayback` data source (correct is even less than wayback machine, [reference](https://support.archive-it.org/hc/en-us/articles/209783963-What-s-the-difference-between-the-General-Archive-and-Archive-It-)), I decided to focus on scraping (`/explore`). I also removed an unnecessary check since we can do it directly in the for loop