### PR TITLE
Added SonarSSL as a data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The OWASP Amass Project performs network mapping of attack surfaces and external
 |:-------------|:-------------|
 | DNS          | Brute forcing, Reverse DNS sweeping, NSEC zone walking, Zone transfers, FQDN alterations/permutations, FQDN Similarity-based Guessing |
 | Scraping     | Ask, Baidu, Bing, BuiltWith, DNSDumpster, DuckDuckGo, HackerOne, IPv4Info, RapidDNS, Riddler, SiteDossier, Yahoo |
-| Certificates | Active pulls (optional), Censys, CertSpotter, Crtsh, FacebookCT, GoogleCT |
+| Certificates | Active pulls (optional), Censys, CertSpotter, Crtsh, FacebookCT, GoogleCT, SonarSSL |
 | APIs         | AlienVault, Anubis, BinaryEdge, BGPView, BufferOver, C99, Chaos, CIRCL, Cloudflare, CommonCrawl, DNSDB, GitHub, HackerTarget, Hunter, IPinfo, Mnemonic, NetworksDB, PassiveTotal, RADb, ReconDev, Robtex, SecurityTrails, ShadowServer, Shodan, SonarSearch, Spyse, Sublist3rAPI, TeamCymru, ThreatBook, ThreatCrowd, ThreatMiner, Twitter, Umbrella, URLScan, VirusTotal, WhoisXMLAPI, ZETAlytics, ZoomEye |
 | Web Archives | ArchiveIt, ArchiveToday, Wayback |
 

--- a/resources/scripts/cert/sonarssl.ads
+++ b/resources/scripts/cert/sonarssl.ads
@@ -1,0 +1,17 @@
+-- Copyright 2021 Jeff Foley. All rights reserved.
+-- Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+name = "SonarSSL"
+type = "scrape"
+
+function start()
+    setratelimit(4)
+end
+
+function vertical(ctx, domain)
+    scrape(ctx, {url=buildurl(domain)})
+end
+
+function buildurl(domain)
+    return "https://sonarssl.herokuapp.com/?q=domain:" .. domain
+end


### PR DESCRIPTION
Hi @caffix :wave:

I recently created a project named SonarSSL that allows searching in the certificate records database that I collected from Rapid7's SSL Certificates OpenData (only 550,000 entries due to load of my service), really want to integrate it with Amass. The "database" gets updated monthly by me. The server is not really strong and fast because of my Heroku plan but I think it still works well

Hope you like it:)