### PR TITLE
Enhanced web crawling feature

### DIFF
--- a/datasrcs/scripting/script_http.go
+++ b/datasrcs/scripting/script_http.go
@@ -203,7 +203,7 @@ func (s *Script) crawl(L *lua.LState) int {
 		return 0
 	}
 
-	names, err := http.Crawl(ctx, string(u), cfg.Domains(), int(max), nil)
+	names, err := http.Crawl(ctx, string(u), cfg.Domains(), int(max), nil, false)
 	if err != nil {
 		if cfg.Verbose {
 			bus.Publish(requests.LogTopic, eventbus.PriorityHigh, fmt.Sprintf("%s: %s: %v", s.String(), u, err))

--- a/enum/active.go
+++ b/enum/active.go
@@ -147,7 +147,7 @@ func (a *activeTask) crawlName(ctx context.Context, req *requests.DNSRequest, tp
 			protocol = "https://"
 		}
 		u := protocol + req.Name + ":" + strconv.Itoa(port)
-		names, err := http.Crawl(ctx, u, cfg.Domains(), 50, a.enum.crawlFilter)
+		names, err := http.Crawl(ctx, u, cfg.Domains(), 50, a.enum.crawlFilter, true)
 		if err != nil {
 			if cfg.Verbose {
 				cfg.Log.Printf("Active Crawl: %v", err)


### PR DESCRIPTION
When crawling directly targets, we should crawl for JS files because they usually contain some private/internal stuff (might have internal hostnames). But for Lua scripts, it usually just crawls archive pages or online web crawlers, anything that gives back a list of URLs. JS files in this situation are just javascript files of the service website, but not the target