### PR TITLE
Bug fixed and added AbuseIPDB as a data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The OWASP Amass Project performs network mapping of attack surfaces and external
 | Technique    | Data Sources |
 |:-------------|:-------------|
 | DNS          | Brute forcing, Reverse DNS sweeping, NSEC zone walking, Zone transfers, FQDN alterations/permutations, FQDN Similarity-based Guessing |
-| Scraping     | Ask, Baidu, Bing, BuiltWith, DNSDumpster, DuckDuckGo, HackerOne, IPv4Info, RapidDNS, Riddler, SiteDossier, Yahoo |
+| Scraping     | AbuseIPDB, Ask, Baidu, Bing, BuiltWith, DNSDumpster, DuckDuckGo, HackerOne, IPv4Info, RapidDNS, Riddler, SiteDossier, Yahoo |
 | Certificates | Active pulls (optional), Censys, CertSpotter, Crtsh, FacebookCT, GoogleCT |
 | APIs         | AlienVault, Anubis, BinaryEdge, BGPView, BufferOver, C99, Chaos, CIRCL, Cloudflare, CommonCrawl, DNSDB, GitHub, HackerTarget, Hunter, IPinfo, Mnemonic, NetworksDB, PassiveTotal, RADb, ReconDev, Robtex, SecurityTrails, ShadowServer, Shodan, SonarSearch, Spyse, Sublist3rAPI, TeamCymru, ThreatBook, ThreatCrowd, ThreatMiner, Twitter, Umbrella, URLScan, VirusTotal, WhoisXMLAPI, ZETAlytics, ZoomEye |
 | Web Archives | ArchiveIt, ArchiveToday, Wayback |

--- a/datasrcs/scripting/script_support.go
+++ b/datasrcs/scripting/script_support.go
@@ -156,7 +156,7 @@ func (s *Script) submatch(L *lua.LState) int {
 		return 1
 	}
 
-	matches := re.FindStringSubmatch(string(str))
+	matches := re.FindAllStringSubmatch(string(str), -1)
 	if matches == nil {
 		L.Push(lua.LNil)
 		return 1
@@ -164,7 +164,9 @@ func (s *Script) submatch(L *lua.LState) int {
 
 	tb := L.NewTable()
 	for _, match := range matches {
-		tb.Append(lua.LString(match))
+		if len(match) > 1 {
+			tb.Append(lua.LString(match[1]))
+		}
 	}
 
 	L.Push(tb)

--- a/doc/scripting.md
+++ b/doc/scripting.md
@@ -405,7 +405,7 @@ end
 
 ### `submatch` Function
 
-The `submatch` function performs simple regular expression pattern matching that supports submatches. The function accepts a string containing content to be searched and a regular expression pattern as [defined by the Go standard library](https://golang.org/pkg/regexp/). The `submatch` function returns a Lua table containing the leftmost match found in the provided string and the submatches. The matches are in the expected order of the 1-based array (table) returned by the function.
+The `submatch` function performs simple regular expression pattern matching that supports submatches. The function accepts a string containing content to be searched and a regular expression pattern as [defined by the Go standard library](https://golang.org/pkg/regexp/). The `submatch` function returns a Lua table containing all the submatches.
 
 ```lua
 function vertical(ctx, domain)
@@ -419,8 +419,10 @@ function vertical(ctx, domain)
 
     local matches = submatch(page, pattern)
     -- Send the first submatch
-    if (matches ~= nil and #matches >=2 and matches[2] ~= "") then
-        newname(ctx, matches[2])
+    if (matches ~= nil and #matches ~= 0 and matches[1] ~= "") then
+        for i, name in pairs(matches) do
+            newname(ctx, name)
+        end
     end
 end
 ```

--- a/resources/scripts/cert/googlect.ads
+++ b/resources/scripts/cert/googlect.ads
@@ -69,11 +69,11 @@ function sendnames(ctx, content)
 end
 
 function gettoken(content)
-    local pattern = "\\[(null|\"[a-zA-Z0-9]+\"),\"([a-zA-Z0-9]+)\",null,([0-9]+),([0-9]+)\\]"
+    local pattern = "\"([a-zA-Z0-9]{39,40})\""
     local match = submatch(content, pattern)
 
-    if (match ~= nil and #match == 5 and (match[4] < match[5])) then
-        return match[3]
+    if (match ~= nil and #match ~= 0) then
+        return match[1]
     end
 
     return ""

--- a/resources/scripts/scrape/abuseipdb.ads
+++ b/resources/scripts/scrape/abuseipdb.ads
@@ -19,7 +19,7 @@ function vertical(ctx, domain)
         return
     end
 
-    local subre = "<li>([\\.a-z0-9]{1,70})</li>"
+    local subre = "<li>([\\.a-z0-9-]{1,70})</li>"
     local matches = submatch(page, subre)
     if (matches == nil or #matches == 0) then
         return

--- a/resources/scripts/scrape/abuseipdb.ads
+++ b/resources/scripts/scrape/abuseipdb.ads
@@ -19,7 +19,7 @@ function vertical(ctx, domain)
         return
     end
 
-    local subre = "<li>([\\.a-z0-9-]{1,70})</li>"
+    local subre = "<li>([.a-z0-9-]{1,70})</li>"
     local matches = submatch(page, subre)
     if (matches == nil or #matches == 0) then
         return

--- a/resources/scripts/scrape/abuseipdb.ads
+++ b/resources/scripts/scrape/abuseipdb.ads
@@ -1,0 +1,70 @@
+-- Copyright 2021 Jeff Foley. All rights reserved.
+-- Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+name = "AbuseIPDB"
+type = "scrape"
+
+function start()
+    setratelimit(1)
+end
+
+function vertical(ctx, domain)
+    local ip = getip(ctx, domain)
+    if (ip == nil or ip == "") then
+        return
+    end
+
+    local page, err = request(ctx, {url=buildurl(ip)})
+    if (err ~= nil and err ~= "") then
+        return
+    end
+
+    local subre = "<li>([\\.a-z0-9]{1,70})</li>"
+    local matches = submatch(page, subre)
+    if (matches == nil or #matches == 0) then
+        return
+    end
+
+    for i, sub in pairs(matches) do
+        local v = sub .. "." .. domain
+        sendnames(ctx, v)
+    end
+end
+
+function buildurl(ip)
+    return "https://www.abuseipdb.com/whois/" .. ip
+end
+
+function getip(ctx, domain)
+    local page, err = request(ctx, {url=ipurl(domain)})
+    if (err ~= nil and err ~= "") then
+        return nil
+    end
+
+    local ipre = "<i\\ class=text\\-primary>(.*)</i>"
+    local matches = submatch(page, ipre)
+    if (matches == nil or #matches == 0) then
+        return nil
+    end
+
+    return matches[1]
+end
+
+function ipurl(domain)
+    return "https://www.abuseipdb.com/check/" .. domain
+end
+
+function sendnames(ctx, content)
+    local names = find(content, subdomainre)
+    if (names == nil) then
+        return
+    end
+
+    local found = {}
+    for i, v in pairs(names) do
+        if (found[v] == nil) then
+            newname(ctx, v)
+            found[v] = true
+        end
+    end
+end


### PR DESCRIPTION
```
$ amass enum -d owasp.org -include abuseipdb -passive -src
[AbuseIPDB]       wiki.owasp.org
[AbuseIPDB]       www.owasp.org
[AbuseIPDB]       lists.owasp.org
[AbuseIPDB]       calendar.owasp.org
[AbuseIPDB]       owaspforce.owasp.org
[AbuseIPDB]       cheesemonkey.owasp.org
[DNS]             owasp.org
[AbuseIPDB]       austin.owasp.org
[AbuseIPDB]       secureflag.owasp.org
[AbuseIPDB]       gapps.owasp.org
[AbuseIPDB]       www2.owasp.org
[AbuseIPDB]       my.owasp.org
[AbuseIPDB]       brainbreak.owasp.org
...
```