### PR TITLE
Added ReverseWhoisIO as a data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The OWASP Amass Project performs network mapping of attack surfaces and external
 | Technique    | Data Sources |
 |:-------------|:-------------|
 | DNS          | Brute forcing, Reverse DNS sweeping, NSEC zone walking, Zone transfers, FQDN alterations/permutations, FQDN Similarity-based Guessing |
-| Scraping     | Ask, Baidu, Bing, BuiltWith, DNSDumpster, DuckDuckGo, HackerOne, IPv4Info, RapidDNS, Riddler, SiteDossier, Yahoo |
+| Scraping     | Ask, Baidu, Bing, BuiltWith, DNSDumpster, DuckDuckGo, HackerOne, IPv4Info, RapidDNS, ReverseWhoisIO, Riddler, SiteDossier, Yahoo |
 | Certificates | Active pulls (optional), Censys, CertSpotter, Crtsh, FacebookCT, GoogleCT |
 | APIs         | AlienVault, Anubis, BinaryEdge, BGPView, BufferOver, C99, Chaos, CIRCL, Cloudflare, CommonCrawl, DNSDB, GitHub, HackerTarget, Hunter, IPinfo, Mnemonic, NetworksDB, PassiveTotal, RADb, ReconDev, Robtex, SecurityTrails, ShadowServer, Shodan, SonarSearch, Spyse, Sublist3rAPI, TeamCymru, ThreatBook, ThreatCrowd, ThreatMiner, Twitter, Umbrella, URLScan, VirusTotal, WhoisXMLAPI, ZETAlytics, ZoomEye |
 | Web Archives | ArchiveIt, ArchiveToday, Wayback |

--- a/resources/scripts/scrape/reversewhoisio.ads
+++ b/resources/scripts/scrape/reversewhoisio.ads
@@ -1,0 +1,30 @@
+-- Copyright 2021 Jeff Foley. All rights reserved.
+-- Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+name = "ReverseWhoisIO"
+type = "scrape"
+
+function start()
+    setratelimit(5)
+end
+
+function horizontal(ctx, domain)
+    local page, err = request(ctx, {url=buildurl(domain)})
+    if (err ~= nil and err ~= "") then
+        return
+    end
+
+    local domainre = "</td><td>(" .. subdomainre .. ")</td>"
+    local matches = submatch(page, domainre)
+    if (matches == nil or #matches == 0) then
+        return
+    end
+
+    for _, name in pairs(matches) do
+        associated(ctx, domain, name)
+    end
+end
+
+function buildurl(domain)
+    return "https://www.reversewhois.io/?searchterm=" .. domain
+end


### PR DESCRIPTION
ReverseWhois.IO is hosted by ViewDNS.info and has similar results to it, but free, no captcha plus limited to first 1000 results

```
$ amass intel -d owasp.org -whois -src
[ReverseWhoisIO]  0daylabs.com
[ReverseWhoisIO]  apis17.net
[ReverseWhoisIO]  appsecapac.com
[ReverseWhoisIO]  appsecapac.org
[ReverseWhoisIO]  appsecasia.com
[ReverseWhoisIO]  appsecasia.org
[ReverseWhoisIO]  appsecasiapac.com
[ReverseWhoisIO]  appsecasiapacific.com
[ReverseWhoisIO]  appsecasiapacific.org
[ReverseWhoisIO]  appsecasiapac.org
[ReverseWhoisIO]  appsecbrasil.org
...
```