### PR TITLE
Added ARIN/AskDNS/DNSlytics/SpyOnWeb as data sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ The OWASP Amass Project performs network mapping of attack surfaces and external
 | Technique    | Data Sources |
 |:-------------|:-------------|
 | DNS          | Brute forcing, Reverse DNS sweeping, NSEC zone walking, Zone transfers, FQDN alterations/permutations, FQDN Similarity-based Guessing |
-| Scraping     | Ask, Baidu, Bing, BuiltWith, DNSDumpster, DuckDuckGo, HackerOne, IPv4Info, RapidDNS, Riddler, SiteDossier, Yahoo |
+| Scraping     | Ask, AskDNS, Baidu, Bing, BuiltWith, DNSDumpster, DuckDuckGo, HackerOne, IPv4Info, RapidDNS, Riddler, SiteDossier, Yahoo |
 | Certificates | Active pulls (optional), Censys, CertSpotter, Crtsh, FacebookCT, GoogleCT |
-| APIs         | AlienVault, Anubis, BinaryEdge, BGPView, BufferOver, C99, Chaos, CIRCL, Cloudflare, CommonCrawl, DNSDB, GitHub, HackerTarget, Hunter, IPinfo, Mnemonic, NetworksDB, PassiveTotal, RADb, ReconDev, Robtex, SecurityTrails, ShadowServer, Shodan, SonarSearch, Spyse, Sublist3rAPI, TeamCymru, ThreatBook, ThreatCrowd, ThreatMiner, Twitter, Umbrella, URLScan, VirusTotal, WhoisXMLAPI, ZETAlytics, ZoomEye |
+| APIs         | ARIN, AlienVault, Anubis, BinaryEdge, BGPView, BufferOver, C99, Chaos, CIRCL, Cloudflare, CommonCrawl, DNSDB, GitHub, HackerTarget, Hunter, IPinfo, Mnemonic, NetworksDB, PassiveTotal, RADb, ReconDev, Robtex, SecurityTrails, ShadowServer, Shodan, SonarSearch, Spyse, Sublist3rAPI, TeamCymru, ThreatBook, ThreatCrowd, ThreatMiner, Twitter, Umbrella, URLScan, VirusTotal, WhoisXMLAPI, ZETAlytics, ZoomEye |
 | Web Archives | ArchiveIt, ArchiveToday, Wayback |
 
 ----

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ The OWASP Amass Project performs network mapping of attack surfaces and external
 | Technique    | Data Sources |
 |:-------------|:-------------|
 | DNS          | Brute forcing, Reverse DNS sweeping, NSEC zone walking, Zone transfers, FQDN alterations/permutations, FQDN Similarity-based Guessing |
-| Scraping     | Ask, AskDNS, Baidu, Bing, BuiltWith, DNSDumpster, DuckDuckGo, HackerOne, IPv4Info, RapidDNS, Riddler, SiteDossier, Yahoo |
+| Scraping     | Ask, AskDNS, Baidu, Bing, BuiltWith, DNSDumpster, DuckDuckGo, HackerOne, IPv4Info, RapidDNS, Riddler, SiteDossier, SpyOnWeb, Yahoo |
 | Certificates | Active pulls (optional), Censys, CertSpotter, Crtsh, FacebookCT, GoogleCT |
-| APIs         | ARIN, AlienVault, Anubis, BinaryEdge, BGPView, BufferOver, C99, Chaos, CIRCL, Cloudflare, CommonCrawl, DNSDB, GitHub, HackerTarget, Hunter, IPinfo, Mnemonic, NetworksDB, PassiveTotal, RADb, ReconDev, Robtex, SecurityTrails, ShadowServer, Shodan, SonarSearch, Spyse, Sublist3rAPI, TeamCymru, ThreatBook, ThreatCrowd, ThreatMiner, Twitter, Umbrella, URLScan, VirusTotal, WhoisXMLAPI, ZETAlytics, ZoomEye |
+| APIs         | ARIN, AlienVault, Anubis, BinaryEdge, BGPView, BufferOver, C99, Chaos, CIRCL, Cloudflare, CommonCrawl, DNSDB, DNSlytics, GitHub, HackerTarget, Hunter, IPinfo, Mnemonic, NetworksDB, PassiveTotal, RADb, ReconDev, Robtex, SecurityTrails, ShadowServer, Shodan, SonarSearch, Spyse, Sublist3rAPI, TeamCymru, ThreatBook, ThreatCrowd, ThreatMiner, Twitter, Umbrella, URLScan, VirusTotal, WhoisXMLAPI, ZETAlytics, ZoomEye |
 | Web Archives | ArchiveIt, ArchiveToday, Wayback |
 
 ----

--- a/examples/config.ini
+++ b/examples/config.ini
@@ -164,6 +164,12 @@ minimum_ttl = 1440 ; One day
 #[data_sources.DNSDB.Credentials]
 #apikey =
 
+# https://dnslytics.com (Paid)
+#[data_sources.DNSlytics]
+#ttl = 1440
+#[data_sources.DNSlytics.Credentials]
+#apikey =
+
 # https://developer.facebook.com (Free)
 # Look here for how to obtain the Facebook credentials:
 # https://goldplugins.com/documentation/wp-social-pro-documentation/how-to-get-an-app-id-and-secret-key-from-facebook/

--- a/resources/scripts/api/arin.ads
+++ b/resources/scripts/api/arin.ads
@@ -1,0 +1,42 @@
+-- Copyright 2021 Jeff Foley. All rights reserved.
+-- Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+local json = require("json")
+
+name = "ARIN"
+type = "api"
+
+function start()
+    setratelimit(1)
+end
+
+function asn(ctx, addr, asn)
+    if addr == "" then
+        return
+    end
+
+    local resp, err = request(ctx, {url=asnurl(addr)})
+    if (err ~= nil and err ~= "") then
+        return
+    end
+
+    local j = json.decode(resp)
+    if (j == nil or j.cidr0_cidrs == nil or j.arin_originas0_originautnums == nil or 
+        #j.cidr0_cidrs == 0 or #j.arin_originas0_originautnums == 0) then
+        return
+    end
+
+    local asn = j.arin_originas0_originautnums[1]
+    local cidr = j.cidr0_cidrs[1]['v4prefix'] .. "/" .. tostring(j.cidr0_cidrs[1]['length'])
+    local desc = j.name .. " - " .. j.entities[1]['vcardArray'][2][2][4]
+    newasn(ctx, {
+        ['addr']=addr,
+        ['asn']=asn,
+        ['desc']=desc,
+        ['prefix']=cidr,
+    })
+end
+
+function asnurl(addr)
+    return "https://rdap.arin.net/registry/ip/" .. addr
+end

--- a/resources/scripts/api/dnslytics.ads
+++ b/resources/scripts/api/dnslytics.ads
@@ -1,0 +1,102 @@
+-- Copyright 2021 Jeff Foley. All rights reserved.
+-- Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+local json = require("json")
+
+name = "DNSlytics"
+type = "api"
+
+function start()
+    setratelimit(1)
+end
+
+function check()
+    local c
+    local cfg = datasrc_config()
+    if cfg ~= nil then
+        c = cfg.credentials
+    end
+
+    if (c ~= nil and c.key ~= nil and c.key ~= "") then
+        return true
+    end
+    return false
+end
+
+function horizontal(ctx, domain)
+    local c
+    local cfg = datasrc_config()
+    if cfg ~= nil then
+        c = cfg.credentials
+    end
+
+    if (c == nil or c.key == nil or c.key == "") then
+        return
+    end
+
+    -- DNSlytics ReverseIP API
+    local resp, err = request(ctx, {url=firsturl(domain, c.key)})
+    if (err ~= nil and err ~= "") then
+        return
+    end
+
+    local d = json.decode(resp)
+    if (d == nil or d.data == nil or d.data['domains'] == nil) then
+        return
+    end
+
+    for i, name in pairs(d.data['domains']) do
+        associated(ctx, domain, name)
+    end
+
+    -- DNSlytics ReverseGAnalytics API
+    resp, err = request(ctx, {url=secondurl(domain, c.key)})
+    if (err ~= nil and err ~= "") then
+        return
+    end
+
+    d = json.decode(resp)
+    if (d == nil or d.data == nil or d.data['domains'] == nil) then
+        return
+    end
+
+    for i, res in pairs(d.data['domains']) do
+        associated(ctx, domain, res['domain'])
+    end
+end
+
+function firsturl(domain, key)
+    return "https://api.dnslytics.net/v1/reverseip/" .. domain .. "?apikey=" .. key
+end
+
+function secondurl(domain, key)
+    return "https://api.dnslytics.net/v1/reverseganalytics/" .. domain .. "?apikey=" .. key
+end
+
+function asn(ctx, addr, asn)
+    if addr == "" then
+        return
+    end
+
+    local resp, err = request(ctx, {url=asnurl(addr)})
+    if (err ~= nil and err ~= "") then
+        return
+    end
+
+    local d = json.decode(resp)
+    if (d == nil or d.announced == false) then
+        return
+    end
+
+    local desc = d.shortname .. ", " .. d.country
+    newasn(ctx, {
+        ['addr']=d.ip,
+        ['asn']=d.asn,
+        ['desc']=desc,
+        ['prefix']=d.cidr,
+    })
+end
+
+function asnurl(addr)
+    return "https://freeapi.dnslytics.net/v1/ip2asn/" .. addr
+end

--- a/resources/scripts/scrape/askdns.ads
+++ b/resources/scripts/scrape/askdns.ads
@@ -1,0 +1,30 @@
+-- Copyright 2021 Jeff Foley. All rights reserved.
+-- Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+name = "AskDNS"
+type = "scrape"
+
+function start()
+    setratelimit(2)
+end
+
+function horizontal(ctx, domain)
+    local page, err = request(ctx, {url=buildurl(domain)})
+    if (err ~= nil and err ~= "") then
+        return
+    end
+
+    local pattern = "\"/domain/(.*)\""
+    local matches = submatch(page, pattern)
+    if (matches == nil or #matches == 0) then
+        return
+    end
+
+    for i, name in pairs(matches) do
+        associated(ctx, domain, name)
+    end
+end
+
+function buildurl(domain)
+    return "https://askdns.com/domain/" .. domain
+end

--- a/resources/scripts/scrape/spyonweb.ads
+++ b/resources/scripts/scrape/spyonweb.ads
@@ -1,0 +1,30 @@
+-- Copyright 2021 Jeff Foley. All rights reserved.
+-- Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+name = "SpyOnWeb"
+type = "scrape"
+
+function start()
+    setratelimit(4)
+end
+
+function horizontal(ctx, domain)
+    local page, err = request(ctx, {url=buildurl(domain)})
+    if (err ~= nil and err ~= "") then
+        return
+    end
+
+    local pattern = "\"/go/([a-z0-9]{2,63}+[.][a-z]{2,3}+([.][a-z]{2}|))\""
+    local matches = submatch(page, pattern)
+    if (matches == nil or #matches == 0) then
+        return
+    end
+
+    for i, name in pairs(matches) do
+        associated(ctx, domain, name)
+    end
+end
+
+function buildurl(domain)
+    return "https://spyonweb.com/" .. domain
+end


### PR DESCRIPTION
*Note: 2 of 4 data sources need `submatch` fix in #676 to be merged*

The results are really realiable

```
$ amass intel -d airbnb.com -whois -src -include askdns
[AskDNS]          airbnb.org
[AskDNS]          vamo.com
[AskDNS]          airbnb.dk
[AskDNS]          airbnb.com.ua
[AskDNS]          airbnb.pl
[AskDNS]          airbnb.fr
[AskDNS]          airbnb.com.tr
[AskDNS]          airbnb.de
[AskDNS]          airbnb.co.za
[AskDNS]          airbnb.co.id
[AskDNS]          airbnb.com.ro
[AskDNS]          airbnb.gr
[AskDNS]          airbnb.es
[AskDNS]          airbnb.co.uk
[AskDNS]          airbnb.ru
[AskDNS]          airbnb.ie
[AskDNS]          airbnb.it
[AskDNS]          airbnb.no
[AskDNS]          airbnb.com.ec
[AskDNS]          airbnb.be
[AskDNS]          airbnb.ca
[AskDNS]          airbnb.co.kr
[AskDNS]          airbnb.com.tw
[AskDNS]          airbnb.com.sg
[AskDNS]          airbnb.com.ee
[AskDNS]          airbnb.co.cr
[AskDNS]          airbnb.com
[AskDNS]          airbnb.com.ar
[AskDNS]          airbnb.ae
[AskDNS]          airbnb.ch
[AskDNS]          airbnb.co.nz
[AskDNS]          airbnb.cz
[AskDNS]          airbnb.co.in
```