### PR TITLE
Updating config to exclude sharing of results

### DIFF
--- a/examples/config.ini
+++ b/examples/config.ini
@@ -2,7 +2,7 @@
 # Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
 # Participating data source providers give service credits when enumeration findings are shared.
-share = true
+#share = false
 
 # Should results only be collected passively and without DNS resolution? Not recommended.
 #mode = passive


### PR DESCRIPTION
Please make the following change to the example to be more consistent (ie, everything commented out, users need to opt in to every service), and to prevent the inadvertent  sending of data to vendors such as SecurityTrails.