### PR TITLE
A lot of data source improvements/refactors/fixes

### DIFF
--- a/resources/scripts/api/github.ads
+++ b/resources/scripts/api/github.ads
@@ -49,7 +49,10 @@ function vertical(ctx, domain)
         end
 
         for i, item in pairs(d.items) do
-            search_item(ctx, item)
+            local ok = search_item(ctx, item)
+            if not ok then
+                return
+            end
         end
     end
 end
@@ -57,18 +60,21 @@ end
 function search_item(ctx, item)
     local info, err = request(ctx, {['url']=item.url})
     if (err ~= nil and err ~= "") then
-        return
+        return false
     end
 
     local data = json.decode(info)
     if (data == nil or data['download_url'] == nil) then
-        return
+        return false
     end
 
     local content, err = request(ctx, {['url']=data['download_url']})
-    if err == nil then
-        send_names(ctx, content)
+    if (err ~= nil and err ~= "") then
+        return false
     end
+
+    send_names(ctx, content)
+    return true
 end
 
 function build_url(domain, pagenum)

--- a/resources/scripts/api/mnemonic.ads
+++ b/resources/scripts/api/mnemonic.ads
@@ -11,24 +11,29 @@ function start()
 end
 
 function vertical(ctx, domain)
-    local page, err = request(ctx, {url=api_url(domain)})
+    local page, err = request(ctx, {url=build_url(domain)})
     if (err ~= nil and err ~= '') then
         return
     end
 
     local resp = json.decode(page)
-    if (resp == nil or resp["responseCode"] ~= 200) then
+    if (resp == nil or resp.responseCode ~= 200 or resp.count == 0) then
         return
     end
 
-    for i, tb in pairs(resp.data) do
-        if ((tb.rrtype == "a" or tb.rrtype == "aaaa") and in_scope(ctx, tb.query)) then
-            new_name(ctx, tb.query)
-            new_addr(ctx, tb.answer, tb.query)
+    for _, tb in pairs(resp.data) do
+        if in_scope(ctx, tb['query']) then
+            new_name(ctx, tb['query'])
+            if (tb['rrtype'] == "a" or tb['rrtype'] == "aaaa") then
+                new_addr(ctx, tb['answer'], tb['query'])
+            end
+        end
+        if (tb['rrtype'] == "cname") then
+            new_name(ctx, tb['answer'])
         end
     end
 end
 
-function api_url(domain)
-    return "https://api.mnemonic.no/pdns/v3/" .. domain
+function build_url(domain)
+    return "https://api.mnemonic.no/pdns/v3/" .. domain .. "?limit=1000"
 end

--- a/resources/scripts/api/threatminer.ads
+++ b/resources/scripts/api/threatminer.ads
@@ -11,17 +11,21 @@ function start()
 end
 
 function vertical(ctx, domain)
-    local resp, err = request(ctx, {url="https://api.threatminer.org/v2/domain.php?q=" .. domain .. "&api=True&rt=5"})
+    local resp, err = request(ctx, {url=build_url(domain)})
     if (err ~= nil and err ~= "") then
         return
     end
 
     local d = json.decode(resp)
-    if (d == nil or d['status_code'] ~= "200" or d['status_message'] ~= "Results found." or #(d.results) == 0) then
+    if (d == nil or d.status_code ~= "200" or #d.results == 0) then
         return
     end
 
-    for i, sub in pairs(d.results) do
+    for _, sub in pairs(d.results) do
         new_name(ctx, sub)
     end
+end
+
+function build_url(domain)
+    return "https://api.threatminer.org/v2/domain.php?rt=5&q=" .. domain
 end

--- a/resources/scripts/api/urlscan.ads
+++ b/resources/scripts/api/urlscan.ads
@@ -7,51 +7,49 @@ name = "URLScan"
 type = "api"
 
 function start()
-    set_rate_limit(2)
+    set_rate_limit(1)
 end
 
 function vertical(ctx, domain)
-    local url = "https://urlscan.io/api/v1/search/?q=domain:" .. domain
-    local resp, err = request(ctx, {['url']=url})
-    if (err ~= nil and err ~= "") then
-        return
+    local uuid = submission(ctx, domain)
+    if (uuid ~= "") then
+        scrape(ctx, {url="https://urlscan.io/api/v1/result/" .. uuid})
     end
 
-    local d = json.decode(resp)
-    if (d == nil or d.total == nil or d.results == nil or #(d.results) == 0) then
-        return
-    end
-
-    if d.total > 0 then
-        for i, r in pairs(d.results) do
-            subs(ctx, r['_id'])
+    local last = nil
+    while(true) do
+        local resp, err = request(ctx, {url=build_url(domain, last)})
+        if (err ~= nil and err ~= "") then
+            return
         end
-        return
-    end
 
-    subs(ctx, submission(ctx, domain))
+        local d = json.decode(resp)
+        if (d == nil or d.total == 0) then
+            return
+        end
+
+        for _, r in pairs(d.results) do
+            local ok = scrape(ctx, {url=r['result']})
+            if not ok then
+                break
+            end
+
+            check_rate_limit()
+            last = tostring(r['sort'][1]) .. "," .. r['sort'][2]
+        end
+
+        if (not ok or d.has_more == false) then
+            break
+        end
+    end
 end
 
-function subs(ctx, id)
-    if id == "" then
-        return
+function build_url(domain, last)
+    local url = "https://urlscan.io/api/v1/search/?q=domain:" .. domain
+    if (last ~= nil) then
+        return url .. "&search_after=" .. last
     end
-
-    local url = "https://urlscan.io/api/v1/result/" .. id .. "/"
-    local resp, err = request(ctx, {['url']=url})
-    if (err ~= nil and err ~= "") then
-        return
-    end
-
-    local d = json.decode(resp)
-    if (d == nil or d.lists == nil or 
-        d.lists.linkDomains == nil or #(d.lists.linkDomains) == 0) then
-        return
-    end
-
-    for i, sub in pairs(d.lists.linkDomains) do
-        new_name(ctx, sub)
-    end
+    return url
 end
 
 function submission(ctx, domain)
@@ -72,38 +70,38 @@ function submission(ctx, domain)
 
     local resp, body, err
     body, err = json.encode({
-        ['url']=domain,
+        url=domain,
         public="on",
-        customagent="OWASP Amass", 
+        customagent="OWASP Amass",
     })
     if (err ~= nil and err ~= "") then
         return ""
     end
 
     resp, err = request(ctx, {
-        ['method']="POST",
-        ['data']=body,
-        ['url']="https://urlscan.io/api/v1/scan/",
-        ['headers']=headers,
+        url="https://urlscan.io/api/v1/scan/",
+        method="POST",
+        data=body,
+        headers=headers,
     })
     if (err ~= nil and err ~= "") then
         return ""
     end
 
     local d = json.decode(resp)
-    if (d == nil or d.message ~= "Submission successful" or #(d.results) == 0) then
+    if (d == nil or #d.results == 0) then
         return ""
     end
 
     -- Keep this data source active while waiting for the scan to complete
-	while(true) do
-        _, err = request(ctx, {['url']=d.api})
-		if (err == nil or err ~= "404 Not Found") then
-			break
+    while(true) do
+        _, err = request(ctx, {url=d.api})
+        if (err == nil or err ~= "404 Not Found") then
+            break
         end
         -- A large pause between these requests
-        for var=1,5 do check_rate_limit() end
-	end
+        for _=1,10 do check_rate_limit() end
+    end
 
-	return d.uuid
+    return d.uuid
 end

--- a/resources/scripts/api/virustotal.ads
+++ b/resources/scripts/api/virustotal.ads
@@ -10,6 +10,19 @@ function start()
     set_rate_limit(10)
 end
 
+function check()
+    local c
+    local cfg = datasrc_config()
+    if cfg ~= nil then
+        c = cfg.credentials
+    end
+
+    if (c ~= nil and c.key ~= nil and c.key ~= "") then
+        return true
+    end
+    return false
+end
+
 function vertical(ctx, domain)
     local c
     local cfg = datasrc_config()
@@ -17,44 +30,30 @@ function vertical(ctx, domain)
         c = cfg.credentials
     end
 
-    local haskey = true
     if (c == nil or c.key == nil or c.key == "") then
-        haskey = false
+        return
     end
 
-    local vurl = "https://www.virustotal.com/ui/domains/" .. domain .. "/subdomains?limit=40"
-    if haskey then
-        vurl = "https://www.virustotal.com/vtapi/v2/domain/report?apikey=" .. c.key .. "&domain=" .. domain
-    end
-
-    local resp, err = request(ctx, {url=vurl})
+    local resp, err = request(ctx, {url=build_url(domain, c.key)})
     if (err ~= nil and err ~= "") then
         return
     end
 
     local d = json.decode(resp)
-    if haskey then
-        if d['response_code'] ~= 1 then
-            log(ctx, name .. ": " .. vurl .. ": Response code " .. d['response_code'] .. ": " .. d['verbose_msg'])
-            return
-        end
-
-        if d.subdomains == nil then
-            return
-        end
-
-        for i, sub in pairs(d.subdomains) do
-            new_name(ctx, sub)
-        end
-    else
-        if d.data == nil then
-            return
-        end
-
-        for i, data in pairs(d.data) do
-            if data.type == "domain" then
-                new_name(ctx, data.id)
-            end
-        end
+    if d.response_code ~= 1 then
+        log(ctx, name .. ": " .. build_url(domain, c.key) .. ": HTTP status " .. d.response_code .. ": " .. d.verbose_msg)
+        return
     end
+
+    if d.subdomains == nil then
+        return
+    end
+
+    for _, sub in pairs(d.subdomains) do
+        new_name(ctx, sub)
+    end
+end
+
+function build_url(domain, key)
+    return "https://www.virustotal.com/vtapi/v2/domain/report?domain=" .. domain .. "&apikey=" .. key
 end

--- a/resources/scripts/archive/archiveit.ads
+++ b/resources/scripts/archive/archiveit.ads
@@ -11,10 +11,10 @@ function start()
 end
 
 function vertical(ctx, domain)
-    scrape(ctx, {url=first_url(domain)})
+    scrape(ctx, {['url']=first_url(domain)})
 
     for i=1,20 do
-        local ok = scrape(ctx, {url=second_url(domain, i)})
+        local ok = scrape(ctx, {['url']=second_url(domain, i)})
         if not ok then
             break
         end

--- a/resources/scripts/archive/archiveit.ads
+++ b/resources/scripts/archive/archiveit.ads
@@ -1,6 +1,8 @@
 -- Copyright 2017-2021 Jeff Foley. All rights reserved.
 -- Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
+local url = require("url")
+
 name = "ArchiveIt"
 type = "archive"
 
@@ -9,42 +11,32 @@ function start()
 end
 
 function vertical(ctx, domain)
-    scrape(ctx, {['url']=first_url(domain)})
+    scrape(ctx, {url=first_url(domain)})
 
-    local found = pages(ctx, domain)
-    if not found then
-        return
-    end
-
-    for i=1,50,1 do
-        local ok = scrape(ctx, {['url']=second_url(domain, i)})
+    for i=1,20 do
+        local ok = scrape(ctx, {url=second_url(domain, i)})
         if not ok then
             break
         end
-
-        check_rate_limit()
     end
 end
 
 function first_url(domain)
-    return "https://wayback.archive-it.org/all/timemap/cdx?matchType=domain&fl=original&collapse=urlkey&url=" .. domain
+    local params = {
+        ['url']=domain,
+        ['matchType']="domain",
+        ['fl']="original",
+        ['collapse']="urlkey",
+    }
+    return "https://wayback.archive-it.org/all/timemap/cdx?" .. url.build_query_string(params)
 end
 
 function second_url(domain, pagenum)
-    return "https://archive-it.org/explore?show=Sites&q=" .. domain .. "&page=" .. pagenum
-end
+    local params = {
+        ['show']="Sites",
+        ['q']=domain,
+        ['page']=pagenum,
+    }
 
-function pages(ctx, domain)
-    local u = "https://archive-it.org/explore?show=Sites&q=" .. domain
-    local resp, err = request(ctx, {['url']=u})
-    if (err ~= nil and err ~= "") then
-        return false
-    end
-
-    local match = find(resp, "No metadata results")
-    if (match == nil or #match == 0) then
-        return false
-    end
-
-    return true
+    return "https://archive-it.org/explore?" .. url.build_query_string(params)
 end

--- a/resources/scripts/cert/censys.ads
+++ b/resources/scripts/cert/censys.ads
@@ -19,10 +19,17 @@ function vertical(ctx, domain)
 
     if (c == nil or c.key == nil or
         c.key == "" or c.secret == nil or c.secret == "") then
+        local certpath_re = "/certificates/[a-z0-9]{64}"
         for i=1,10 do
-            local ok = scrape(ctx, {url=build_url(domain, i)})
-            if not ok then
-                break
+            local page, err = request(ctx, {url=build_url(domain, i)})
+            if (err ~= nil and err ~= "") then
+                return
+            end
+
+            local paths = find(page, certpath_re)
+            for _, path in pairs(paths) do
+                local cert_url = "https://censys.io" .. path
+                scrape(ctx, {url=cert_url})
             end
         end
         return

--- a/resources/scripts/cert/censys.ads
+++ b/resources/scripts/cert/censys.ads
@@ -17,13 +17,22 @@ function vertical(ctx, domain)
         c = cfg.credentials
     end
 
-    if (c == nil or c.key == nil or 
+    if (c == nil or c.key == nil or
         c.key == "" or c.secret == nil or c.secret == "") then
-        scrape(ctx, {url="https://www.censys.io/domain/" .. domain .. "/table"})
+        for i=1,10 do
+            local ok = scrape(ctx, {url=build_url(domain, i)})
+            if not ok then
+                break
+            end
+        end
         return
     end
 
     api_query(ctx, cfg, domain)
+end
+
+function build_url(domain, pagenum)
+    return "https://censys.io/certificates/_search?q=" .. domain .. "&page=" .. pagenum
 end
 
 function api_query(ctx, cfg, domain)
@@ -32,38 +41,38 @@ function api_query(ctx, cfg, domain)
     while(true) do
         local err, body, resp
         body, err = json.encode({
-            query="parsed.names: " .. domain, 
-            page=p,
-            fields={"parsed.names"},
+            ['query']="parsed.names: " .. domain,
+            ['page']=p,
+            ['fields']={"parsed.names"},
         })
         if (err ~= nil and err ~= "") then
             return
         end
-    
+
         resp, err = request(ctx, {
             method="POST",
             data=body,
             url="https://www.censys.io/api/v1/search/certificates",
             headers={['Content-Type']="application/json"},
-            id=cfg["credentials"].key,
-            pass=cfg["credentials"].secret,
+            id=cfg['credentials'].key,
+            pass=cfg['credentials'].secret,
         })
         if (err ~= nil and err ~= "") then
             return
         end
 
         local d = json.decode(resp)
-        if (d == nil or d.status ~= "ok" or #(d.results) == 0) then
+        if (d == nil or d.status ~= "ok" or #d.results == 0) then
             return
         end
 
-        for i, r in pairs(d.results) do
-            for j, v in pairs(r["parsed.names"]) do
+        for _, r in pairs(d.results) do
+            for _, v in pairs(r['parsed.names']) do
                 new_name(ctx, v)
             end
         end
 
-        if d["metadata"].page >= d["metadata"].pages then
+        if d['metadata'].page >= d['metadata'].pages then
             return
         end
 

--- a/resources/scripts/scrape/abuseipdb.ads
+++ b/resources/scripts/scrape/abuseipdb.ads
@@ -25,7 +25,7 @@ function vertical(ctx, domain)
         return
     end
 
-    for i, match in pairs(matches) do
+    for _, match in pairs(matches) do
         if (match ~= nil and #match >=2) then
             local name = match[2] .. "." .. domain
             send_names(ctx, name)
@@ -58,19 +58,4 @@ end
 
 function ip_url(domain)
     return "https://www.abuseipdb.com/check/" .. domain
-end
-
-function send_names(ctx, content)
-    local names = find(content, subdomain_regex)
-    if (names == nil) then
-        return
-    end
-
-    local found = {}
-    for i, v in pairs(names) do
-        if (found[v] == nil) then
-            new_name(ctx, v)
-            found[v] = true
-        end
-    end
 end

--- a/resources/scripts/scrape/gists.ads
+++ b/resources/scripts/scrape/gists.ads
@@ -13,7 +13,7 @@ end
 function vertical(ctx, domain)
     local gist_re = "https://gist[.]github[.]com/[a-zA-Z0-9-]{1,39}/[a-z0-9]{32}"
     for i=1,20 do
-        local resp, err = request(ctx, {url=build_url(domain, i)})
+        local resp, err = request(ctx, {['url']=build_url(domain, i)})
         if (err ~= nil and err ~= "") then
             break
         end
@@ -24,7 +24,7 @@ function vertical(ctx, domain)
         end
 
         for _, gist in pairs(gists) do
-            scrape(ctx, {url=gist})
+            scrape(ctx, {['url']=gist})
         end
         check_rate_limit()
     end

--- a/resources/scripts/scrape/gists.ads
+++ b/resources/scripts/scrape/gists.ads
@@ -12,7 +12,7 @@ end
 
 function vertical(ctx, domain)
     local gist_re = "https://gist[.]github[.]com/[a-zA-Z0-9-]{1,39}/[a-z0-9]{32}"
-    for i=1,10 do
+    for i=1,20 do
         local resp, err = request(ctx, {url=build_url(domain, i)})
         if (err ~= nil and err ~= "") then
             break
@@ -23,8 +23,8 @@ function vertical(ctx, domain)
             break
         end
 
-        for i, url in pairs(gists) do
-            scrape(ctx, {['url']=url})
+        for _, gist in pairs(gists) do
+            scrape(ctx, {url=gist})
         end
         check_rate_limit()
     end
@@ -32,9 +32,9 @@ end
 
 function build_url(domain, pagenum)
     local params = {
-        ref="searchresults",
-        q=domain,
-        p=pagenum,
+        ['ref']="searchresults",
+        ['q']=domain,
+        ['p']=pagenum,
     }
     return "https://gist.github.com/search?" .. url.build_query_string(params)
 end

--- a/resources/scripts/scrape/ipv4info.ads
+++ b/resources/scripts/scrape/ipv4info.ads
@@ -15,7 +15,7 @@ function vertical(ctx, domain)
     end
 
     local url = "http://ipv4info.com/subdomains/" .. token .. "/" .. domain .. ".html"
-    local resp, err = request(ctx, {url=url})
+    local resp, err = request(ctx, {['url']=url})
     if (err ~= nil and err ~= "") then
         return
     end
@@ -42,7 +42,7 @@ end
 
 function get_token(ctx, domain)
     local url = "http://ipv4info.com/search/NF/" .. domain
-    local page, err = request(ctx, {url=url})
+    local page, err = request(ctx, {['url']=url})
     if (err ~= nil and err ~= "") then
         return ""
     end
@@ -67,7 +67,7 @@ function next_page(ctx, domain, resp, page)
     end
 
     local url = "http://ipv4info.com" .. match[1]
-    local page, err = request(ctx, {url=url})
+    local page, err = request(ctx, {['url']=url})
     if (err ~= nil and err ~= "") then
         return ""
     end

--- a/resources/scripts/scrape/ipv4info.ads
+++ b/resources/scripts/scrape/ipv4info.ads
@@ -9,18 +9,13 @@ function start()
 end
 
 function vertical(ctx, domain)
-    local path = get_path(ctx, domain)
-    if path == "" then
-        return
-    end
-
-    local token = get_token(ctx, domain, path)
+    local token = get_token(ctx, domain)
     if token == "" then
         return
     end
 
-    local u = "http://ipv4info.com/subdomains/" .. token .. "/" .. domain .. ".html"
-    local resp, err = request(ctx, {['url']=u})
+    local url = "http://ipv4info.com/subdomains/" .. token .. "/" .. domain .. ".html"
+    local resp, err = request(ctx, {url=url})
     if (err ~= nil and err ~= "") then
         return
     end
@@ -45,24 +40,9 @@ function vertical(ctx, domain)
     end
 end
 
-function get_path(ctx, domain)
-    local u = "http://ipv4info.com/search/" .. domain
-    local page, err = request(ctx, {['url']=u})
-    if (err ~= nil and err ~= "") then
-        return ""
-    end
-
-    local match = find(page, "/ip-address/(.*)/" .. domain)
-    if (match == nil or #match == 0) then
-        return ""
-    end
-
-    return match[1]
-end
-
-function get_token(ctx, domain, path)
-    local u = "http://ipv4info.com" .. path
-    local page, err = request(ctx, {['url']=u})
+function get_token(ctx, domain)
+    local url = "http://ipv4info.com/search/NF/" .. domain
+    local page, err = request(ctx, {url=url})
     if (err ~= nil and err ~= "") then
         return ""
     end
@@ -86,8 +66,8 @@ function next_page(ctx, domain, resp, page)
         return ""
     end
 
-    local u = "http://ipv4info.com" .. match[1]
-    local page, err = request(ctx, {['url']=u})
+    local url = "http://ipv4info.com" .. match[1]
+    local page, err = request(ctx, {url=url})
     if (err ~= nil and err ~= "") then
         return ""
     end

--- a/resources/scripts/scrape/sitedossier.ads
+++ b/resources/scripts/scrape/sitedossier.ads
@@ -5,7 +5,7 @@ name = "SiteDossier"
 type = "scrape"
 
 function start()
-    set_rate_limit(2)
+    set_rate_limit(4)
 end
 
 function vertical(ctx, domain)
@@ -17,6 +17,7 @@ function vertical(ctx, domain)
             break
         end
 
+        check_rate_limit()
         p = p + 100
     end
 end


### PR DESCRIPTION
Some explanations:
- Mnemonic: Grep hostnames from all rrtype, not just `a` and `aaaa` + increase the results limit to 1000 (default: 25)
- SecurityTrails: Scrape associated domains from more than 1 page
- ThreatMiner: Remove a useless parameter in API URL
- URLScan: Scrape the whole submission page (not just `linkDomains`, but also `sanNames`, ...) + next paging
- VirusTotal: Remove the free API query because Captcha was implemented
- IPv4Info: Search page is no longer working, so used another way
- SiteDossier: Increase rate limit