### PR TITLE
Allow JSON output to write to STDOUT for file named `-`

### DIFF
--- a/cmd/amass/db.go
+++ b/cmd/amass/db.go
@@ -348,11 +348,20 @@ func writeJSON(args *dbArgs, uuids []string, assets []*requests.Output, db *netm
 		d.Names = append(d.Names, asset)
 	}
 
-	jsonptr, err := os.OpenFile(args.Filepaths.JSONOutput, os.O_WRONLY|os.O_CREATE, 0644)
-	if err != nil {
-		r.Fprintf(color.Error, "Failed to open the JSON output file: %v\n", err)
-		return
+	var jsonptr *os.File
+	var err error
+
+	// Write to STDOUT and not a file if named "-"
+	if args.Filepaths.JSONOutput == "-" {
+		jsonptr = os.Stdout
+	} else {
+		jsonptr, err = os.OpenFile(args.Filepaths.JSONOutput, os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			r.Fprintf(color.Error, "Failed to open the JSON output file: %v\n", err)
+			return
+		}
 	}
+
 	// Remove previously stored data and encode the JSON
 	_ = jsonptr.Truncate(0)
 	_, _ = jsonptr.Seek(0, 0)


### PR DESCRIPTION
Scope of PR
==========

- [x] Avoid file creation and write to `stdout` for `db` subcommand when file passed is `-` along with `-json` flag.
- [x] Avoid file creation and write to `stdout` for `enum` subcommand when file passed is `-` along with `-json` flag.
   - [x] Run `printOutput` routine only when JSON file is not `-` 

Fixes #708 