### PR TITLE
Fix for "permission denied" error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ ENV HOME /
 RUN addgroup user \
     && adduser user -D -G user \
     && mkdir /.config \
+    && mkdir /.config/amass \
     && chown -R user:user /.config
 USER user
 ENTRYPOINT ["/bin/amass"]


### PR DESCRIPTION
When using docker like `docker run -v amass_data:/.config/amass/ amass ...`, amass folder inside /.config is created under root so user can't create files inside:
> Failed to open the log file: open /.config/amass/amass.log: permission denied

