### PR TITLE
Fix CleanName bug

### DIFF
--- a/net/http/http.go
+++ b/net/http/http.go
@@ -48,7 +48,7 @@ var (
 	// UserAgent is the default user agent used by Amass during HTTP requests.
 	UserAgent   string
 	subRE       = dns.AnySubdomainRegex()
-	nameStripRE = regexp.MustCompile(`^u[0-9a-f]{4}|20|22|25|27|2b|2f|3d|3a|40`)
+	nameStripRE = regexp.MustCompile(`^(u[0-9a-f]{4}|20|22|25|27|2b|2f|3d|3a|40)`)
 )
 
 // DefaultClient is the same HTTP client used by the package methods.

--- a/net/http/http_test.go
+++ b/net/http/http_test.go
@@ -276,6 +276,10 @@ func TestCleanName(t *testing.T) {
 			data: "http://www.owasp.org/index.html",
 			want: "www.owasp.org",
 		},
+		{
+			data: "http://blackhat2018.owasp.org/index.html",
+			want: "blackhat2018.owasp.org",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
when abcd2013.xx.xx, it will output 13.xx.xx

But I have a place don't understand, if the domain name to begin with "20", will not error output this domain name

