### PR TITLE
docker: adding workdir in final image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,5 @@ RUN addgroup user \
     && mkdir /.config/amass \
     && chown -R user:user /.config
 USER user
+WORKDIR /home/user
 ENTRYPOINT ["/bin/amass"]


### PR DESCRIPTION
**Issue**
When running with docker:
```bash
docker run -v OUTPUT_DIR_PATH:/.config/amass/ caffix/amass:latest enum -passive -d owasp.org -o owasp.txt
Failed to open the text output file: open owasp.txt: permission denied
```

**Fix**
Adding `WORKDIR` in the final image put the entrypoint command to run and create files in the correct directory.

**New feature**
Now is possible to execute a simple command using docker like:
```bash
docker run -v OUTPUT_DIR_PATH:/home/user caffix/amass:latest enum -d owasp.org -o owasp.txt
```

**ToDo**
- Adding an example in the `install.md`