### PR TITLE
Revamped docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ sudo snap install amass
 
 1. Install [Docker](https://www.docker.com)
 2. Pull the Docker image by running `docker pull caffix/amass`
-3. Run `docker run -v OUTPUT_DIR_PATH:/.config/amass/ caffix/amass enum -d example.com`
+3. Run `docker run -it --rm -v OUTPUT_DIR_PATH:/amass/ caffix/amass enum -d example.com`
 
 The volume argument allows the Amass graph database to persist between executions and output files to be accessed on the host system. The first field (left of the colon) of the volume option is the amass output directory that is external to Docker, while the second field is the path, internal to Docker, where amass will write the output files.
 

--- a/doc/install.md
+++ b/doc/install.md
@@ -18,6 +18,11 @@ Using this installation option on macOS is could result in an 'unidentified deve
 
 ## Using Docker
 
+To avoid output files being owned by root on your host, consider configuring Docker Rootless OR Linux Namespaces
+- [Run the Docker daemon as a non-root user (Rootless mode)](https://docs.docker.com/engine/security/rootless/)
+- [Isolate containers with a user namespace](https://docs.docker.com/engine/security/userns-remap/)
+- [Use Linux user namespaces to fix permissions in docker volumes](https://www.jujens.eu/posts/en/2017/Jul/02/docker-userns-remap/)
+
 1. Build the [Docker](https://docs.docker.com/) image:
 
 ```bash
@@ -27,7 +32,7 @@ docker build -t amass https://github.com/OWASP/Amass.git
 2. Run the Docker image:
 
 ```bash
-docker run -v OUTPUT_DIR_PATH:/.config/amass/ amass enum --list
+docker run -it --rm -v OUTPUT_DIR_PATH:/amass/ amass enum --list
 ```
 
 The volume argument allows the Amass graph database to persist between executions and output files to be accessed on the host system. The first field (left of the colon) of the volume option is the amass output directory that is external to Docker, while the second field is the path, internal to Docker, where amass will write the output files.
@@ -35,7 +40,7 @@ The volume argument allows the Amass graph database to persist between execution
 The wordlists maintained in the Amass git repository are available in `/examples/wordlists/` within the docker container. For example, to use `all.txt`:
 
 ```bash
-docker run -v OUTPUT_DIR_PATH:/.config/amass/ amass enum -brute -w /wordlists/all.txt -share -d example.com
+docker run -it --rm -v OUTPUT_DIR_PATH:/amass/ amass enum -brute -w /wordlists/all.txt -share -d example.com
 ```
 
 ## From Source

--- a/doc/user_guide.md
+++ b/doc/user_guide.md
@@ -36,7 +36,7 @@ $ amass enum -v -src -ip -brute -min-for-recursive 2 -d example.com
 Executing the tool via the Docker image:
 
 ```bash
-docker run -v OUTPUT_DIR_PATH:/.config/amass/ caffix/amass:latest enum --list
+docker run -it --rm -v OUTPUT_DIR_PATH:/amass/ caffix/amass:latest enum --list
 ```
 
 The volume argument allows the Amass graph database to persist between executions and output files to be accessed on the host system. The first field (left of the colon) of the volume option is the amass output directory that is external to Docker, while the second field is the path, internal to Docker, where amass will write the output files.


### PR DESCRIPTION
The current Dockerfile configures a user account inside the container, which can cause issues such as in PR #796 

This Dockerfile runs `amass` as `root` inside the container which alleviates any permission issues that may arise.
Consequently, I've added some resources to `install.md` which will help users configure permissions on their host.

Further, we no longer modify `$HOME` to be all of `/` - instead we symlink `/root/.config/amass` to `/amass` which in turn simplifies the Docker Mount arguments.

Lastly, according to `install.md`, `examples/wordlists/` should be in `/wordlists` in the container, but isn't. 
Initially I intended to copy the directory from the build context, but I noticed that it is ignored in the `.dockerignonre`. 
I wasn't quite sure why this was done so I left it as is & cloned the sub-directory in the `builder` stage.

The resulting image is available to be pulled from `frost19k/amass:latest` for testing.