### PR TITLE
Support to allow an output file prefix added to 'viz' to resolve #310

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
+
+# Jetbrains IDE configuration files
+.idea

--- a/cmd/amass/viz.go
+++ b/cmd/amass/viz.go
@@ -37,11 +37,12 @@ type vizArgs struct {
 		Silent     bool
 	}
 	Filepaths struct {
-		ConfigFile string
-		Directory  string
-		Domains    string
-		Input      string
-		Output     string
+		ConfigFile    string
+		Directory     string
+		Domains       string
+		Input         string
+		Output        string
+		AllFilePrefix string
 	}
 }
 
@@ -65,6 +66,7 @@ func runVizCommand(clArgs []string) {
 	vizCommand.StringVar(&args.Filepaths.Domains, "df", "", "Path to a file providing root domain names")
 	vizCommand.StringVar(&args.Filepaths.Input, "i", "", "The Amass data operations JSON file")
 	vizCommand.StringVar(&args.Filepaths.Output, "o", "", "Path to the directory for output files being generated")
+	vizCommand.StringVar(&args.Filepaths.AllFilePrefix, "oA", "", "Path prefix used for naming all output files")
 	vizCommand.BoolVar(&args.Options.D3, "d3", false, "Generate the D3 v4 force simulation HTML file")
 	vizCommand.BoolVar(&args.Options.DOT, "dot", false, "Generate the DOT output file")
 	vizCommand.BoolVar(&args.Options.GEXF, "gexf", false, "Generate the Gephi Graph Exchange XML Format (GEXF) file")
@@ -156,6 +158,13 @@ func runVizCommand(clArgs []string) {
 	nodes, edges := viz.VizData(context.Background(), memDB, uuids)
 	// Get the directory to save the files into
 	dir := args.Filepaths.Directory
+
+	// Set output file prefix, use 'amass' if '-oA' flag is not specified
+	prefix := args.Filepaths.AllFilePrefix
+	if prefix == "" {
+		prefix = "amass"
+	}
+
 	if args.Filepaths.Output != "" {
 		if finfo, err := os.Stat(args.Filepaths.Output); os.IsNotExist(err) || !finfo.IsDir() {
 			r.Fprintln(color.Error, "The output location does not exist or is not a directory")
@@ -164,23 +173,23 @@ func runVizCommand(clArgs []string) {
 		dir = args.Filepaths.Output
 	}
 	if args.Options.D3 {
-		path := filepath.Join(dir, "amass_d3.html")
+		path := filepath.Join(dir, prefix+".html")
 		err = writeGraphOutputFile("d3", path, nodes, edges)
 	}
 	if args.Options.DOT {
-		path := filepath.Join(dir, "amass.dot")
+		path := filepath.Join(dir, prefix+".dot")
 		err = writeGraphOutputFile("dot", path, nodes, edges)
 	}
 	if args.Options.GEXF {
-		path := filepath.Join(dir, "amass.gexf")
+		path := filepath.Join(dir, prefix+".gexf")
 		err = writeGraphOutputFile("gexf", path, nodes, edges)
 	}
 	if args.Options.Graphistry {
-		path := filepath.Join(dir, "amass_graphistry.json")
+		path := filepath.Join(dir, prefix+"_graphistry.json")
 		err = writeGraphOutputFile("graphistry", path, nodes, edges)
 	}
 	if args.Options.Maltego {
-		path := filepath.Join(dir, "amass_maltego.csv")
+		path := filepath.Join(dir, prefix+"_maltego.csv")
 		err = writeGraphOutputFile("maltego", path, nodes, edges)
 	}
 	if err != nil {

--- a/doc/user_guide.md
+++ b/doc/user_guide.md
@@ -152,10 +152,13 @@ Switches for outputting the DNS and infrastructure findings as a network graph:
 | -df | Path to a file providing root domain names | amass viz -d3 -df domains.txt |
 | -dir | Path to the directory containing the graph database | amass viz -d3 -dir PATH -d example.com |
 | -enum | Identify an enumeration via an index from the db listing | amass viz -enum 1 -d3 -d example.com |
-| -gexf | Output to Graph Exchange XML Format (GEXF) | amass viz -gephi -d example.com |
+| -o | Path to a pre-existing directory that will hold output files | amass viz -d3 -o OUTPATH -d example.com |
+| -oA | Prefix used for naming all output files | amass viz -d3 -oA example -d example.com |
+| -gexf | Output to Graph Exchange XML Format (GEXF) | amass viz -gexf -d example.com |
 | -graphistry | Output Graphistry JSON | amass viz -graphistry -d example.com |
 | -i | Path to the Amass data operations JSON input file | amass viz -d3 -d example.com |
 | -maltego | Output a Maltego Graph Table CSV file | amass viz -maltego -d example.com |
+
 
 ### The 'track' Subcommand
 


### PR DESCRIPTION
Work done in response to issue #310.  

> Also it would be super handy if users were able to specify the actual filename for the output here, because iterating over multiple domains means a bunch of manual work to include copy and move operations to sort out the destination file name

The '-oA' command now allows the user to optionally specify an output file prefix, with 'amass' being used as a default. 

Instructions for the new '-oA' flag was included in the README.md. In addition, corrected instructions for the '-o' and  '-gexf' flags were also amended.  

Finally, configuration files for Jetbrains IDEs were added to the .gitignore to assist in maintaining the [repo's](url) continued cleanliness.