### PR TITLE
Intel domain active cert #802

### DIFF
--- a/cmd/amass/intel.go
+++ b/cmd/amass/intel.go
@@ -168,7 +168,7 @@ func runIntelCommand(clArgs []string) {
 
 	// Some input validation
 	if !args.Options.ReverseWhois && args.OrganizationName == "" && !args.Options.ListSources &&
-		len(args.Addresses) == 0 && len(args.CIDRs) == 0 && len(args.ASNs) == 0 {
+		len(args.Addresses) == 0 && len(args.CIDRs) == 0 && len(args.ASNs) == 0 && args.Domains.Len() == 0 {
 		commandUsage(intelUsageMsg, intelCommand, intelBuf)
 		os.Exit(1)
 	}

--- a/intel/active.go
+++ b/intel/active.go
@@ -111,14 +111,19 @@ func (a *activeTask) certEnumeration(ctx context.Context, req *requests.AddrRequ
 		return
 	}
 
-	ip := net.ParseIP(req.Address)
-	if ip == nil {
-		return
+	host := req.Domain
+	addrinfo := requests.AddressInfo{}
+	if req.Domain == "" {
+		host = req.Address
+		ip := net.ParseIP(req.Address)
+		if ip == nil {
+			return
+		}
+		addrinfo.Address = ip
 	}
 
 	c := a.c
-	addrinfo := requests.AddressInfo{Address: ip}
-	for _, name := range http.PullCertificateNames(ctx, req.Address, c.Config.Ports) {
+	for _, name := range http.PullCertificateNames(ctx, host, c.Config.Ports) {
 		if n := strings.TrimSpace(name); n != "" {
 			domain, err := publicsuffix.EffectiveTLDPlusOne(n)
 			if err != nil {

--- a/requests/request.go
+++ b/requests/request.go
@@ -216,7 +216,7 @@ func (a *AddrRequest) MarkAsProcessed() {}
 
 // Valid performs input validation of the receiver.
 func (a *AddrRequest) Valid() bool {
-	if ip := net.ParseIP(a.Address); ip == nil {
+	if ip := net.ParseIP(a.Address); ip == nil && a.Domain == "" {
 		return false
 	}
 	if a.Domain != "" {


### PR DESCRIPTION
Add "Active Cert" functionality on domain names for intel as suggested in issue #802 . 
Today with SNI (server name indication) a different TLS certificate can be sent by the host depending on the server name provided. Thus, allowing the "Active Cert" functionality with domain names can help to find more domains.
