### PR TITLE
Refactor config/resolvers.go, update resolvers_test.go

### DIFF
--- a/config/resolvers.go
+++ b/config/resolvers.go
@@ -97,58 +97,36 @@ loop:
 
 // SetResolvers assigns the untrusted resolver names provided in the parameter to the list in the configuration.
 func (c *Config) SetResolvers(resolvers ...string) {
-	c.Resolvers = []string{}
-	c.AddResolvers(resolvers...)
-}
-
-// AddResolvers appends the untrusted resolver names provided in the parameter to the list in the configuration.
-func (c *Config) AddResolvers(resolvers ...string) {
-	for _, r := range resolvers {
-		c.AddResolver(r)
+	for _, resolver := range resolvers {
+		func() {
+			c.Lock()
+			defer c.Unlock()
+			// Check that the domain string is not empty
+			r := strings.TrimSpace(resolver)
+			if r == "" {
+				return
+			}
+			c.Resolvers = stringset.Deduplicate(append(c.Resolvers, resolver))
+		}()
 	}
 	c.CalcMaxQPS()
-}
-
-// AddResolver appends the untrusted resolver name provided in the parameter to the list in the configuration.
-func (c *Config) AddResolver(resolver string) {
-	c.Lock()
-	defer c.Unlock()
-
-	// Check that the domain string is not empty
-	r := strings.TrimSpace(resolver)
-	if r == "" {
-		return
-	}
-
-	c.Resolvers = stringset.Deduplicate(append(c.Resolvers, resolver))
 }
 
 // SetTrustedResolvers assigns the trusted resolver names provided in the parameter to the list in the configuration.
-func (c *Config) SetTrustedResolvers(resolvers ...string) {
-	c.Resolvers = []string{}
-	c.AddResolvers(resolvers...)
-}
-
-// AddTrustedResolvers appends the trusted resolver names provided in the parameter to the list in the configuration.
-func (c *Config) AddTrustedResolvers(resolvers ...string) {
-	for _, r := range resolvers {
-		c.AddTrustedResolver(r)
+func (c *Config) SetTrustedResolvers(trustedResolvers ...string) {
+	for _, trustedResolver := range trustedResolvers {
+		func() {
+			c.Lock()
+			defer c.Unlock()
+			// Check that the domain string is not empty
+			r := strings.TrimSpace(trustedResolver)
+			if r == "" {
+				return
+			}
+			c.TrustedResolvers = stringset.Deduplicate(append(c.TrustedResolvers, trustedResolver))
+		}()
 	}
 	c.CalcMaxQPS()
-}
-
-// AddTrustedResolver appends the trusted resolver name provided in the parameter to the list in the configuration.
-func (c *Config) AddTrustedResolver(resolver string) {
-	c.Lock()
-	defer c.Unlock()
-
-	// Check that the domain string is not empty
-	r := strings.TrimSpace(resolver)
-	if r == "" {
-		return
-	}
-
-	c.TrustedResolvers = stringset.Deduplicate(append(c.TrustedResolvers, resolver))
 }
 
 // CalcMaxQPS updates the MaxDNSQueries field of the configuration based on current settings.

--- a/config/resolvers_test.go
+++ b/config/resolvers_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 )
 
+var cfg = NewConfig()
+
 func TestConfigSetResolvers(t *testing.T) {
 	type fields struct {
 		config *Config
@@ -40,5 +42,28 @@ func TestConfigSetResolvers(t *testing.T) {
 					tt.args.resolvers, tt.fields.config.Resolvers)
 			}
 		})
+	}
+}
+
+func TestGetPublicDNSResolvers(t *testing.T) {
+	err := GetPublicDNSResolvers()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if len(PublicResolvers) <= 0 {
+		t.Error("No resolvers obtained")
+	} else if PublicResolvers == nil {
+		t.Error("PublicResolvers is a nil slice")
+	}
+}
+
+func BenchmarkTestPublicDNSResolvers(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		err := GetPublicDNSResolvers()
+		if err != nil {
+			b.Error(err)
+			return
+		}
 	}
 }

--- a/config/resolvers_test.go
+++ b/config/resolvers_test.go
@@ -14,7 +14,7 @@ type fields struct {
 }
 
 type args struct {
-	resolvers []string
+	resolvers, trustedResolvers []string
 }
 
 var tests = []struct {
@@ -26,7 +26,8 @@ var tests = []struct {
 		name:   "success",
 		fields: fields{config: &Config{}},
 		args: args{
-			resolvers: []string{"127.0.0.1", "127.0.0.2", "127.0.0.3"},
+			resolvers:        []string{"127.0.0.1", "127.0.0.2", "127.0.0.3"},
+			trustedResolvers: DefaultBaselineResolvers,
 		},
 	},
 }
@@ -37,9 +38,25 @@ func TestConfigSetResolvers(t *testing.T) {
 			tt.fields.config.SetResolvers(tt.args.resolvers...)
 
 			sort.Strings(tt.fields.config.Resolvers)
+			sort.Strings(tt.args.resolvers)
 			if !reflect.DeepEqual(tt.args.resolvers, tt.fields.config.Resolvers) {
 				t.Errorf("SetResolvers() = %v, want %v",
 					tt.args.resolvers, tt.fields.config.Resolvers)
+			}
+		})
+	}
+}
+
+func TestConfigSetTrustedResolvers(t *testing.T) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.fields.config.SetTrustedResolvers(tt.args.trustedResolvers...)
+
+			sort.Strings(tt.fields.config.TrustedResolvers)
+			sort.Strings(tt.args.trustedResolvers)
+			if !reflect.DeepEqual(tt.args.trustedResolvers, tt.fields.config.TrustedResolvers) {
+				t.Errorf("SetTrustedResolvers() = %v, want %v",
+					tt.args.trustedResolvers, tt.fields.config.TrustedResolvers)
 			}
 		})
 	}
@@ -50,6 +67,16 @@ func BenchmarkTestConfigSetResolvers(b *testing.B) {
 		for _, tt := range tests {
 			b.Run(tt.name, func(b *testing.B) {
 				tt.fields.config.SetResolvers(tt.args.resolvers...)
+			})
+		}
+	}
+}
+
+func BenchmarkTestConfigSetTrustedResolvers(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		for _, tt := range tests {
+			b.Run(tt.name, func(b *testing.B) {
+				tt.fields.config.SetTrustedResolvers(tt.args.trustedResolvers...)
 			})
 		}
 	}

--- a/config/resolvers_test.go
+++ b/config/resolvers_test.go
@@ -9,29 +9,29 @@ import (
 	"testing"
 )
 
-var cfg = NewConfig()
+type fields struct {
+	config *Config
+}
+
+type args struct {
+	resolvers []string
+}
+
+var tests = []struct {
+	name   string
+	fields fields
+	args   args
+}{
+	{
+		name:   "success",
+		fields: fields{config: &Config{}},
+		args: args{
+			resolvers: []string{"127.0.0.1", "127.0.0.2", "127.0.0.3"},
+		},
+	},
+}
 
 func TestConfigSetResolvers(t *testing.T) {
-	type fields struct {
-		config *Config
-	}
-	type args struct {
-		resolvers []string
-	}
-
-	tests := []struct {
-		name   string
-		fields fields
-		args   args
-	}{
-		{
-			name:   "success",
-			fields: fields{config: &Config{}},
-			args: args{
-				resolvers: []string{"127.0.0.1", "127.0.0.2", "127.0.0.3"},
-			},
-		},
-	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.fields.config.SetResolvers(tt.args.resolvers...)
@@ -42,6 +42,16 @@ func TestConfigSetResolvers(t *testing.T) {
 					tt.args.resolvers, tt.fields.config.Resolvers)
 			}
 		})
+	}
+}
+
+func BenchmarkTestConfigSetResolvers(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		for _, tt := range tests {
+			b.Run(tt.name, func(b *testing.B) {
+				tt.fields.config.SetResolvers(tt.args.resolvers...)
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
Hello @caffix 
- Unit and benchmark tests added to `config/resolvers_tests.go` to improve code coverage for methods in `config/resolvers.go`
- Moved functionality of `AddResolvers` and `AddResolver` methods into `SetResolvers`
- Moved functionality of `AddTrustedResolvers` and `AddTrustedResolver` methods into `SetTrustedResolvers`