### PR TITLE
fix: panic on json encoding

### DIFF
--- a/cmd/amass/enum.go
+++ b/cmd/amass/enum.go
@@ -523,6 +523,8 @@ func saveJSONOutput(e *enum.Enumeration, args *enumArgs, output chan *requests.O
 	// Save all the output returned by the enumeration
 	for out := range output {
 		// Handle encoding the result as JSON
+		out.Mu.Lock()
+		defer out.Mu.Unlock()
 		_ = enc.Encode(out)
 	}
 }

--- a/requests/request.go
+++ b/requests/request.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"strings"
 	"time"
+	"sync"
 
 	amassdns "github.com/OWASP/Amass/v3/net/dns"
 	"github.com/caffix/pipeline"
@@ -288,6 +289,7 @@ type WhoisRequest struct {
 
 // Output contains all the output data for an enumerated DNS name.
 type Output struct {
+	Mu sync.Mutex
 	Name      string        `json:"name"`
 	Domain    string        `json:"domain"`
 	Addresses []AddressInfo `json:"addresses"`


### PR DESCRIPTION
using json output sometimes trigger a panic, issue seems to happen because a goroutine modify the output object while it is being encoded, adding a mutex solve the issue