### PR TITLE
Fixed panic during output #800

### DIFF
--- a/cmd/amass/enum.go
+++ b/cmd/amass/enum.go
@@ -545,8 +545,20 @@ func processOutput(ctx context.Context, g *netmap.Graph, e *enum.Enumeration, ou
 			if !o.Complete(e.Config.Passive) || !e.Config.IsDomainInScope(o.Name) {
 				continue
 			}
+			//This is to create deep copies of the result object... it's not the most elegant way...
+			reusultObjectData, err := json.Marshal(o)
+			if err != nil {
+				r.Fprintln(color.Error, "Failed to create deep copies of results for output")
+				os.Exit(1)
+			}
 			for _, ch := range outputs {
-				ch <- o
+				var resultObject *requests.Output
+				err = json.Unmarshal(reusultObjectData, &resultObject)
+				if err != nil {
+					r.Fprintln(color.Error, "Failed to create deep copies of results for output")
+					os.Exit(1)
+				}
+				ch <- resultObject
 			}
 		}
 	}


### PR DESCRIPTION
Currently processOutput() is writing only references of the objects to output to the different output channels (text, json, print). However, the saveTextOutput() function actually modifies that data structure which causes a concurrent json marshal on the same data structure to panic as the data being marsheled is modified by another thread.

This PR proposes deep copies of the output objects being written into the different output channels as it seems to me to be the most sane solution. 

The alternatives would have been to either have output mutex-locked, which would still have the disadvantage of saveTextOutput() modifying the data, so you would have a different output depending on whether or not saveTextOutput() happened to run prior or later than your current output as it modifies the data. The other alternative would have been to just modify saveTextOutput(), but that isn't future-proof as in the future someone might write a new output function or modify an existing one in a way that it modifies the data again which would cause everything to break all over again.

I know creating a deep copy through json.Marshal() and json.Unmarshal() is not the most elegant way of creating a deep copy, but it shouldn't cause too much overhead compared to writing functions to do that manually using reflections. 