### PR TITLE
Add RISC-V host support

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,6 +13,10 @@ jobs:
       matrix:
         os: [ "ubuntu-latest", "macos-latest", "windows-latest" ]
         go-version: [ "1.24.0" ]
+        include:
+         - os: self-hosted  # Add a native RISC-V leg that uses your self-hosted riscv64 runner
+           runs_on: [ self-hosted, Linux, riscv64 ] 
+           go-version: '1.24.0'
     runs-on: ${{ matrix.os }}
     env:
       CGO_ENABLED: 0


### PR DESCRIPTION
## TL;DR

Add RISC-V native build and release CI files.  
Tested on [Milk-V Pioneer Box](https://milkv.io/pioneer). Logs are available [here](https://github.com/akifejaz/amass/actions/runs/17431453029).

tagging #1079 

---

## Details
As this tool is written in go which is already ported on RISC-V so, I had no issue compiling this natively for RISC-V. I've added the build and release CI files in this PR, which I tested on Milk-V Pioneer Box. 
Please review the build logs [here](https://github.com/akifejaz/amass/actions/runs/17431453029)

I'm using GitHub CI Runner from [Cloud-V](https://cloud-v.co/), please see the registration page [here](https://cloud-v.co/github-riscv-runner). 

## Notes
I'm Akif from @[10xEngineers](https://10xengineers.ai/) working as part of official RISC-V Lab Partner ([Cloud-V](https://riscv.org/developers/labs/)). I'm mainly working on increasing the SW support for RISC-V and with that intention I'm creating this PR, hoping to get this merged and have release from owasp-amass for RISC-V too.

- Please review the PR and logs
- I can provide access to RISC-V hardware if maintainers would like to enable official releases for riscv64.

