### PR TITLE
fix: bump version to match with release

### DIFF
--- a/internal/afmt/print.go
+++ b/internal/afmt/print.go
@@ -31,7 +31,7 @@ const Banner = `        .+++:.            :                             .+++.
 
 const (
 	// Version is used to display the current version of Amass.
-	Version = "v5.0.0"
+	Version = "v5.0.1"
 
 	// Author is used to display the Amass Project Team.
 	Author = "OWASP Amass Project - @owaspamass"


### PR DESCRIPTION
closes https://github.com/owasp-amass/amass/issues/1081

relates to https://github.com/Homebrew/homebrew-core/pull/236213