### PR TITLE
Fix: Make Version dynamically injectable via -ldflags

### DIFF
--- a/internal/afmt/print.go
+++ b/internal/afmt/print.go
@@ -30,9 +30,6 @@ const Banner = `        .+++:.            :                             .+++.
         +o&&&&+.                                                    +oooo.`
 
 const (
-	// Version is used to display the current version of Amass.
-	Version = "v5.0.0"
-
 	// Author is used to display the Amass Project Team.
 	Author = "OWASP Amass Project - @owaspamass"
 
@@ -44,6 +41,10 @@ const (
 )
 
 var (
+
+	// Version is used to display the current version of Amass.
+	Version = "unknown"
+
 	// Colors used to ease the reading of program output
 	B       = color.New(color.FgHiBlue)
 	Y       = color.New(color.FgHiYellow)


### PR DESCRIPTION
Fix for issue #1087 
Currently, the Version in Amass is hardcoded as v5.0.0. This PR changes Version to a variable that can be set dynamically at build time using -ldflags.

Changes:
-Replaced const Version = "v5.0.0" with a var Version = "unknown" in internal/afmt/print.go.
-Updated build instructions to allow setting the version with:
`go build -ldflags="-X github.com/owasp-amass/amass/v5/internal/afmt.Version=v5.0.1" ./cmd/amass`

Here are the outputs :

<img width="733" height="508" alt="image" src="https://github.com/user-attachments/assets/1e4957b1-72fb-487a-85cf-0fad0052b93a" />
<img width="872" height="508" alt="image" src="https://github.com/user-attachments/assets/5e244fa7-c836-4f2d-a483-81d498ad96f0" />
