### PR TITLE
Fix missing node edges for NS-delegated subzones

### DIFF
--- a/engine/plugins/dns/subs.go
+++ b/engine/plugins/dns/subs.go
@@ -321,11 +321,17 @@ func (d *dnsSubs) process(e *et.Event, results []*relSubs) {
 			continue
 		}
 
-		_ = e.Dispatcher.DispatchEvent(&et.Event{
+		ev := &et.Event{
 			Name:    fname.Name,
 			Entity:  finding.alias,
 			Session: e.Session,
-		})
+		}
+		// propagate the DNS record type so downstream handlers
+		// (e.g. dnsApex) know this FQDN has DNS records
+		if finding.rtype == "dns_record" {
+			support.AddDNSRecordType(ev, int(dns.TypeNS))
+		}
+		_ = e.Dispatcher.DispatchEvent(ev)
 
 		tname, ok := finding.target.Asset.(*oamdns.FQDN)
 		if !ok || tname == nil {


### PR DESCRIPTION
Sorry, I accidentally ran a `git force push`, so I've closed #1116 .  
There are no differences in the changes.

----

I have investigated a discrepancy where some subdomains previously output by the `enum` command in `v3.23.3` no longer appear when using the `subs` command in `v5.1.1` .

## Summary

Fix a regression where intermediate FQDNs under NS-delegated subzones were not appearing in `amass subs -show` output, despite being stored in the database.

## Problem

When a subdomain like `test.example.com` is delegated to a separate DNS server via NS records (and has no A/AAAA records itself), the `dnsApex` handler fails to create a `node` edge from the parent zone apex (`example.com`) to the delegated subzone (`test.example.com`).

This causes `FindByFQDNScope` to be unable to traverse from the root domain to any FQDNs nested under the delegated subzone, resulting in missing entries in CLI output.

### Root cause

`dnsSubs.process()` dispatches events for discovered FQDNs with `Meta = nil`. The `dnsApex.check()` handler returns early when `e.Meta == nil` or when `FQDNMeta.RecordTypes` is empty. Since NS-only FQDNs have no A/AAAA records, the DNS-IP handler never populates `RecordTypes`, so Meta remains nil and `dnsApex` never creates the `node` edge.

## Changes

- `engine/plugins/dns/subs.go`

In `dnsSubs.process()`, set `RecordTypes` with `dns.TypeNS` on the dispatched event for FQDNs that have DNS records. This allows `dnsApex.check()` to pass its Meta guard and create the `node` edge from the parent apex to the NS-delegated subzone.