### PR TITLE
Fix HTTP-Probes attaching redirect target's certificate to http origin

### DIFF
--- a/engine/plugins/service_discovery/http_probes/fqdn_endpoint.go
+++ b/engine/plugins/service_discovery/http_probes/fqdn_endpoint.go
@@ -117,12 +117,7 @@ func (fe *fqdnEndpoint) probeOnePort(e *et.Event, host *dbt.Entity, port int, ch
 	fqdn := host.Asset.(*oamdns.FQDN)
 	addr := fqdn.Name + ":" + strconv.Itoa(port)
 
-	proto := "https"
-	if port == 80 || port == 8080 {
-		proto = "http"
-	}
-
-	ch <- fe.plugin.query(e, host, proto+"://"+addr, port)
+	ch <- fe.plugin.query(e, host, portScheme(port)+"://"+addr, port)
 }
 
 func (fe *fqdnEndpoint) process(e *et.Event, findings []*support.Finding) {

--- a/engine/plugins/service_discovery/http_probes/ipaddr_endpoint.go
+++ b/engine/plugins/service_discovery/http_probes/ipaddr_endpoint.go
@@ -124,12 +124,7 @@ func (r *ipaddrEndpoint) probeOnePort(e *et.Event, ipaddr *dbt.Entity, port int,
 	}
 	addr := a + ":" + strconv.Itoa(port)
 
-	proto := "https"
-	if port == 80 || port == 8080 {
-		proto = "http"
-	}
-
-	ch <- r.plugin.query(e, ipaddr, proto+"://"+addr, port)
+	ch <- r.plugin.query(e, ipaddr, portScheme(port)+"://"+addr, port)
 }
 
 func (r *ipaddrEndpoint) process(e *et.Event, findings []*support.Finding) {

--- a/engine/plugins/service_discovery/http_probes/plugin.go
+++ b/engine/plugins/service_discovery/http_probes/plugin.go
@@ -21,6 +21,13 @@ import (
 	oamplat "github.com/owasp-amass/open-asset-model/platform"
 )
 
+func portScheme(port int) string {
+	if port == 80 || port == 8080 {
+		return "http"
+	}
+	return "https"
+}
+
 type httpProbing struct {
 	name    string
 	log     *slog.Logger
@@ -119,13 +126,19 @@ func (hp *httpProbing) store(e *et.Event, resp *amasshttp.Response, entity *dbt.
 	serv.OutputLen = int(resp.Length)
 	serv.Attributes = resp.Header
 
+	// resp.TLS may come from a cross-scheme redirect, so only trust it on HTTPS ports.
 	var c *oamcert.TLSCertificate
-	firstAsset, firstCert, findings := hp.createCertificates(e.Session, resp)
-	if firstAsset != nil {
-		var valid bool
-		c, valid = firstAsset.Asset.(*oamcert.TLSCertificate)
-		if !valid {
-			return findings
+	var firstAsset *dbt.Entity
+	var firstCert *x509.Certificate
+	var findings []*support.Finding
+	if portScheme(port) == "https" {
+		firstAsset, firstCert, findings = hp.createCertificates(e.Session, resp)
+		if firstAsset != nil {
+			var valid bool
+			c, valid = firstAsset.Asset.(*oamcert.TLSCertificate)
+			if !valid {
+				return findings
+			}
 		}
 	}
 

--- a/engine/plugins/service_discovery/http_probes/plugin_test.go
+++ b/engine/plugins/service_discovery/http_probes/plugin_test.go
@@ -1,0 +1,25 @@
+// Copyright © by Jeff Foley 2017-2026. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+// SPDX-License-Identifier: Apache-2.0
+
+package http_probes
+
+import "testing"
+
+func TestPortScheme(t *testing.T) {
+	cases := []struct {
+		port int
+		want string
+	}{
+		{80, "http"},
+		{8080, "http"},
+		{443, "https"},
+		{8443, "https"},
+	}
+	for _, tc := range cases {
+		got := portScheme(tc.port)
+		if got != tc.want {
+			t.Errorf("portScheme(%d) = %q, want %q", tc.port, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Disclaimer up front: I'm **not** a Go developer and this PR was AI-assisted. I traced the code paths carefully and the build/test passes, but please treat it as a good-faith contribution. Careful inspection would be appreciated.

## Summary

`HTTP-Probes` attaches the redirect target's TLS certificate to the http port's `Service` asset. When `http://host:80` 301/302s to `https://host:443`, the port-80 service gets a `certificate` edge to the port-443 cert. The HTTPS service records the same cert from its own probe, so the http port's link is just misleading.

## Root cause

The probe HTTP client uses Go's default redirect behavior, which crosses schemes freely. After a redirect, `resp.TLS` reflects the final hop's handshake. `httpProbing.store` calls `createCertificates(...)` unconditionally. The probed scheme is decided by an inline `port == 80 || port == 8080` check in `fqdnEndpoint.probeOnePort` and `ipaddrEndpoint.probeOnePort`, but `store` has no access to that predicate.

## Changes

Extract the port → scheme rule into a `portScheme` helper. Both `probeOnePort` sites call it, and `store` gates `createCertificates` on `portScheme(port) == "https"`. Small unit test for the predicate.

I considered setting `CheckRedirect` on the probe client instead, but that would also change which body, headers, and status code get recorded. Trade-off: if port 443 is out of scope but port 80 redirects to it, the cert is no longer captured. That seemed right since the cert belongs to a service that wasn't asked about, but happy to revisit.

## One thing I noticed

More of a suggestion than anything for this PR. `portScheme` quietly assumes every port it sees is HTTP-relevant. That holds today, but won't **if** a future SSH or SMTP probe plugin shares `Scope.Ports`. You'd probably want per-plugin port lists or a shared port-to-protocol classifier. `portScheme` is unexported and can be folded into something broader later without disturbing this fix.