### PR TITLE
Warn when v5 sees -brute / bruteforce.wordlists (#1122)

### DIFF
--- a/internal/enum/cli.go
+++ b/internal/enum/cli.go
@@ -148,6 +148,10 @@ func CLIWorkflow(cmdName string, clArgs []string) {
 		return
 	}
 
+	// Surface configuration that v5 currently parses but does not act on, so users
+	// don't silently get less than they asked for. See issue #1122.
+	warnUnsupportedConfig(cfg, color.Error)
+
 	if err := tools.CreateOutputDirectory(cfg.Dir); err != nil {
 		_, _ = afmt.R.Fprintf(color.Error, "Failed to create the output directory: %v\n", err)
 		os.Exit(1)
@@ -487,6 +491,30 @@ func (e Args) OverrideConfig(conf *config.Config) error {
 	// Attempt to add the provided domains to the configuration
 	conf.AddDomains(e.Domains.Slice()...)
 	return nil
+}
+
+// warnUnsupportedConfig writes a warning to out for every configuration option
+// that v5 parses but does not currently act on, so users don't silently get
+// less than they asked for. See https://github.com/owasp-amass/amass/issues/1122.
+//
+// At present:
+//
+//   - Wordlist brute forcing (-brute, -w/-wm, and the bruteforce.* YAML keys)
+//     is parsed and stored on the config but no engine plugin reads it. The
+//     v4 brute_forcing.ads script has not yet been ported to a v5 plugin, and
+//     the BruteForcing toggle currently only gates FQDN-Alterations.
+//
+// Each warning is a single line so users see it even with quiet log levels.
+func warnUnsupportedConfig(cfg *config.Config, out io.Writer) {
+	if cfg == nil {
+		return
+	}
+	if cfg.BruteForcing && len(cfg.Wordlist) > 0 {
+		_, _ = afmt.Y.Fprintln(out,
+			"warning: wordlist brute forcing (-brute / bruteforce.wordlists) is not implemented in v5 yet; "+
+				"-brute currently only gates FQDN alterations and the supplied wordlist is ignored. "+
+				"Track https://github.com/owasp-amass/amass/issues/1122 for status.")
+	}
 }
 
 func printScope(c *client.Client, token uuid.UUID) {

--- a/internal/enum/cli_test.go
+++ b/internal/enum/cli_test.go
@@ -1,0 +1,75 @@
+// Copyright © by Jeff Foley 2017-2025. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+// SPDX-License-Identifier: Apache-2.0
+
+package enum
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/owasp-amass/amass/v5/config"
+)
+
+// TestWarnUnsupportedConfig pins the warning emitted for the v5 wordlist
+// brute-force gap reported in https://github.com/owasp-amass/amass/issues/1122.
+func TestWarnUnsupportedConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         *config.Config
+		wantWarning bool
+	}{
+		{
+			name:        "nil config does nothing",
+			cfg:         nil,
+			wantWarning: false,
+		},
+		{
+			name:        "no brute, no wordlist",
+			cfg:         &config.Config{},
+			wantWarning: false,
+		},
+		{
+			name: "brute toggled on but no wordlist supplied",
+			cfg: &config.Config{
+				BruteForcing: true,
+			},
+			wantWarning: false,
+		},
+		{
+			name: "wordlist supplied but brute disabled",
+			cfg: &config.Config{
+				Wordlist: []string{"foo", "bar"},
+			},
+			wantWarning: false,
+		},
+		{
+			name: "brute on with wordlist - warns",
+			cfg: &config.Config{
+				BruteForcing: true,
+				Wordlist:     []string{"foo", "bar"},
+			},
+			wantWarning: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			warnUnsupportedConfig(tc.cfg, &buf)
+			out := buf.String()
+
+			if tc.wantWarning {
+				if !strings.Contains(out, "wordlist brute forcing") {
+					t.Errorf("expected wordlist brute-force warning, got %q", out)
+				}
+				if !strings.Contains(out, "issues/1122") {
+					t.Errorf("expected warning to reference issue #1122, got %q", out)
+				}
+			} else if out != "" {
+				t.Errorf("expected no warning, got %q", out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Refs #1122.

@je-bugshell pointed out that v5 still parses the \`-brute\` CLI flag and the \`bruteforce.wordlists\` YAML key — \`cfg.BruteForcing\` and \`cfg.Wordlist\` get populated from CLI (\`internal/enum/cli.go:451\`) and YAML (\`config/brute.go\`), respectively — but **nothing in \`engine/\` reads \`cfg.Wordlist\`**. The only plugin in \`engine/plugins/brute/\` is \`alterations.go\`, which uses \`cfg.AltWordlist\` (a separate field), and the \`BruteForcing\` toggle is reused there to mean "also do alterations." A v4 user expects \`-brute -w wordlist.txt\` to generate \`<word>.example.com\` guesses; in v5 they currently get nothing of the sort.

The issue body offers two paths:
1. Port the v4 wordlist brute-force script to a v5 plugin.
2. If a port isn't on the roadmap, log a clear warning so users aren't silently getting less than they asked for.

I went with **path 2** here, since the porting question is yours to answer. @je-bugshell explicitly offered (1) as a follow-up if you decide to take it; this PR doesn't preempt that.

## Change

- New \`warnUnsupportedConfig\` helper in \`internal/enum/cli.go\`, called from \`CLIWorkflow\` immediately after \`argsAndConfig\`. It emits a single yellow line on \`color.Error\` if both \`cfg.BruteForcing\` and \`cfg.Wordlist\` are set, telling the user wordlist brute forcing isn't implemented in v5 yet, that \`-brute\` currently only gates FQDN alterations, and pointing at issue #1122 for status.
- No warning is emitted when only one of the two is set (a YAML wordlist alone with no \`-brute\`, or \`-brute\` with no wordlist) so existing alterations-only workflows aren't noisy.

## Test

\`internal/enum/cli_test.go\` (new file) — \`TestWarnUnsupportedConfig\` covers 5 cases:
- nil config → no warning
- empty config → no warning
- \`-brute\` only → no warning
- wordlist only → no warning
- \`-brute\` + wordlist → warning emitted, references issue #1122

```
$ go test ./internal/enum/ -run TestWarnUnsupportedConfig -v
=== RUN   TestWarnUnsupportedConfig
--- PASS: TestWarnUnsupportedConfig (0.00s)
ok  	github.com/owasp-amass/amass/v5/internal/enum	0.011s
```

\`go vet ./internal/enum/...\` is clean.

## Notes

- I did **not** add this to \`oam_enum\` or other binaries — only \`amass enum\` reaches \`CLIWorkflow\`. If you'd like the warning surfaced from \`oam_enum\` too, happy to lift it into a shared helper.
- Once the porting question is answered, this warning is one line to remove (or to repoint at a "deprecated, see X" message). It's intentionally cheap to undo.