### PR TITLE
fix: make the native libpostal backend opt-in

### DIFF
--- a/internal/libpostal/cgo_specific.go
+++ b/internal/libpostal/cgo_specific.go
@@ -1,4 +1,4 @@
-//go:build cgo
+//go:build cgo && libpostal
 
 // Copyright © by Jeff Foley 2017-2026. All rights reserved.
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.

--- a/internal/libpostal/pure_go.go
+++ b/internal/libpostal/pure_go.go
@@ -1,4 +1,4 @@
-//go:build !cgo
+//go:build !cgo || !libpostal
 
 // Copyright © by Jeff Foley 2017-2026. All rights reserved.
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.


### PR DESCRIPTION
Native libpostal was getting picked whenever cgo was on. On a pretty normal Linux box, that makes `go test ./...` blow up if `pkg-config` cant find libpostal, even though the HTTP fallback is already there.

This makes the native path opt-in via `-tags libpostal`. Default builds use the fallback now, tagged builds still use the cgo backend. Small fix, but it saves a dumb install footgun.

Repro
```bash
go env CGO_ENABLED
go test ./...
```

Before
```text
Package 'libpostal', required by 'virtual:world', not found
```

Checks
```bash
go test ./...
go list -f '{{.GoFiles}} {{.CgoFiles}}' ./internal/libpostal
go list -tags libpostal -f '{{.GoFiles}} {{.CgoFiles}}' ./internal/libpostal
```

On this machine the default path now picks `pure_go.go`, and the tagged path still picks `cgo_specific.go`.
