### PR TITLE
fix: use colon-free timestamp in engine log filename (#1072)

### DIFF
--- a/internal/amass_engine/cli.go
+++ b/internal/amass_engine/cli.go
@@ -107,7 +107,7 @@ func CLIWorkflow(cmdName string, clArgs []string) {
 }
 
 func selectLogger(dir string) (*slog.Logger, error) {
-	filename := fmt.Sprintf("amass_engine_%s.log", time.Now().Format("2006-01-02T15:04:05"))
+	filename := fmt.Sprintf("amass_engine_%s.log", time.Now().Format("2006-01-02T15-04-05"))
 
 	if dir != "" {
 		return tools.NewFileLogger(dir, filename)


### PR DESCRIPTION
Fixes #1072.

The colon is reserved in Windows paths, so the log filename selectLogger builds from a 2006-01-02T15:04:05 timestamp can't be opened there - amass engine -log-dir logs fails right away with "The filename, directory name, or volume label syntax is incorrect."

Swapped the time portion of the layout from 15:04:05 to 15-04-05 so the name is valid on Windows and Unix. Only the on-disk filename changes; timestamps in log content, the date portion, and the amass_engine_ prefix are untouched. A name now looks like amass_engine_2025-07-16T16-21-54.log.

go build and go vet are clean on internal/amass_engine. I couldn't run the full go build ./... since the libpostal cgo package needs a native library that isn't on my build host, but that's unrelated to this change.
