### PR TITLE
fix(dns): honor blacklist during NS/MX subdomain traversal

### DIFF
--- a/engine/plugins/dns/subs.go
+++ b/engine/plugins/dns/subs.go
@@ -145,6 +145,11 @@ func (d *dnsSubs) traverse(e *et.Event, dom string, fqdn *dbt.Entity, since time
 	for labels := strings.Split(sub, "."); dlen <= len(labels); labels = labels[1:] {
 		sub = strings.TrimSpace(strings.Join(labels, "."))
 
+		// respect the blacklist instead of feeding excluded names back into the engine
+		if e.Session.Scope().IsBlacklisted(&oamdns.FQDN{Name: sub}) {
+			continue
+		}
+
 		// no need to check subdomains already evaluated
 		if d.fqdnAvailable(e, sub) {
 			results := d.lookup(e, sub, since)


### PR DESCRIPTION
## Summary

#1102 (merged, fixing #1086) wired up `Scope.IsBlacklisted`/`AddBlacklist` and made `IsAssetInScope()` reject blacklisted names, but that check isn't consulted everywhere a name can enter the graph DB. `dnsSubs.traverse` (engine/plugins/dns/subs.go) walks every label level between a discovered FQDN and its registered domain, looking up and storing NS/MX-derived subdomains along the way via `dnsSubs.query` -> `dnsSubs.store` -> `DB().CreateAsset`, without ever checking the blacklist. So a name the user explicitly blacklisted can still get looked up and persisted whenever it shows up as an intermediate label during this traversal — matching the report in #1109: seeding `owasp.org` and blacklisting `test.owasp.org` still results in `test.owasp.org` being added to the DB and enumerated.

## Changes

- `engine/plugins/dns/subs.go`: skip a candidate subdomain label in `traverse()` if `Scope.IsBlacklisted()` reports it's blacklisted, before it reaches `lookup`/`query`/`store`.

Note: I don't have a Go toolchain available in the environment I used to write this fix, so I was unable to run `go build`/`go test`/`gofmt` locally. The change is a small, syntactically-verified addition (checked by hand against the `Session`/`Scope` interfaces and identical `oamdns.FQDN{Name: ...}` / `IsBlacklisted` call patterns already used elsewhere in this codebase, e.g. in `scope.go` and other plugin files). Please run CI and let me know if anything needs adjusting.

Fixes #1109