### PR TITLE
fix: avoid colons in generated log filename on Windows

### DIFF
--- a/internal/amass_engine/cli.go
+++ b/internal/amass_engine/cli.go
@@ -107,7 +107,9 @@ func CLIWorkflow(cmdName string, clArgs []string) {
 }
 
 func selectLogger(dir string) (*slog.Logger, error) {
-	filename := fmt.Sprintf("amass_engine_%s.log", time.Now().Format("2006-01-02T15:04:05"))
+	// Colons are illegal in filenames on Windows, so avoid the default
+	// RFC 3339-style separator when building the log filename.
+	filename := fmt.Sprintf("amass_engine_%s.log", time.Now().Format("2006-01-02T15-04-05"))
 
 	if dir != "" {
 		return tools.NewFileLogger(dir, filename)


### PR DESCRIPTION
## Summary

`amass engine -log-dir <dir>` fails on Windows with:
```
Failed to create the logger: failed to open the log file: open logs\amass_engine_2025-07-16T16:21:54.log: The filename, directory name, or volume label syntax is incorrect.
```

`selectLogger` in `internal/amass_engine/cli.go` builds the log filename
with `time.Now().Format("2006-01-02T15:04:05")`, which produces colons
(`:`) in the timestamp. Colons are reserved characters in Windows
filenames (and NTFS ADS syntax), so any attempt to create the file fails.

I checked the other places in the codebase that use a colon-containing
time format (`internal/track/cli.go`, `internal/viz/cli.go`,
`internal/afmt/slog.go`, `engine/plugins/support/normalization.go`) —
none of them use the formatted string as part of a filename, so this is
the only spot that needed a filename-safe format.

## Changes

- `internal/amass_engine/cli.go`: change the log filename's timestamp
  format from `2006-01-02T15:04:05` to `2006-01-02T15-04-05`, replacing
  colons with hyphens so the resulting path is valid on Windows (and
  still sortable/readable).

**Note**: I don't have a Go toolchain available in this environment to
run `go build`/`go vet`/`gofmt` on this change, so it's unverified beyond
manual inspection — the edit is a single string-literal change with no
syntax risk, but flagging this per the repo's own risk-disclosure
expectations for external contributions.

Fixes #1072